### PR TITLE
fix(cicd): Use D1 database ID from secrets with --remote flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Initialize D1 Database Schema (Production)
         if: github.event_name == 'release'
         run: |
-          wrangler d1 execute prod-memenow-upload-metadata --file=schema.sql
+          wrangler d1 execute ${{ secrets.PROD_D1_DATABASE_ID }} --remote --file=schema.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -71,7 +71,7 @@ jobs:
       - name: Initialize D1 Database Schema (Preview)
         if: github.event_name == 'push'
         run: |
-          wrangler d1 execute dev-memenow-upload-metadata --file=schema.sql
+          wrangler d1 execute ${{ secrets.DEV_D1_DATABASE_ID }} --remote --file=schema.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
Fix D1 schema initialization step that fails with "Couldn't find a D1 DB with the name or binding" by using database IDs from secrets instead of hardcoded names, and adding the required `--remote` flag.

## Related
- CI failure: https://github.com/memenow/memenow-storage-cf-workers/actions/runs/24214777962

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| D1 schema init (preview) | `wrangler d1 execute dev-memenow-upload-metadata` | `wrangler d1 execute $DEV_D1_DATABASE_ID --remote` | Uses secret, adds --remote |
| D1 schema init (prod) | `wrangler d1 execute prod-memenow-upload-metadata` | `wrangler d1 execute $PROD_D1_DATABASE_ID --remote` | Uses secret, adds --remote |

## Details
### Root cause
1. Hardcoded database names (`dev-memenow-upload-metadata`) did not match the actual D1 database names in Cloudflare
2. Wrangler 4.x defaults to local D1 execution — `--remote` is required to target remote databases in CI

### Fix
Replace hardcoded names with `${{ secrets.DEV_D1_DATABASE_ID }}` / `${{ secrets.PROD_D1_DATABASE_ID }}` and add `--remote` flag.

## Testing
- Verified `DEV_D1_DATABASE_ID` and `PROD_D1_DATABASE_ID` secrets exist in repo settings
- CI will validate on merge

## Breaking changes
- Not applicable

## Risks and rollout
- Low risk — only changes the D1 schema initialization step, deploy steps are unchanged

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted