### PR TITLE
fix(cicd): Use D1 binding name for schema initialization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Initialize D1 Database Schema (Production)
         if: github.event_name == 'release'
         run: |
-          wrangler d1 execute ${{ secrets.PROD_D1_DATABASE_ID }} --remote --file=schema.sql
+          wrangler d1 execute UPLOAD_DB --remote --file=schema.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -71,7 +71,8 @@ jobs:
       - name: Initialize D1 Database Schema (Preview)
         if: github.event_name == 'push'
         run: |
-          wrangler d1 execute ${{ secrets.DEV_D1_DATABASE_ID }} --remote --file=schema.sql
+          sed -i "s/^database_id = .*/database_id = \"${{ secrets.DEV_D1_DATABASE_ID }}\"/" wrangler.toml
+          wrangler d1 execute UPLOAD_DB --remote --file=schema.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
Fix D1 schema initialization by using the `UPLOAD_DB` binding name instead of passing a UUID directly. `wrangler d1 execute` treats its positional argument as a database **name**, not an ID.

## Related
- Previous fix: #25
- CI failure: https://github.com/memenow/memenow-storage-cf-workers/actions/runs/24219660590

## Changes
- **Production**: `wrangler d1 execute UPLOAD_DB --remote` (resolves `database_id` from wrangler.toml)
- **Preview**: Temporarily swaps `database_id` to `DEV_D1_DATABASE_ID` via sed before executing, so the binding resolves to the dev database