### PR TITLE
refactor(core): Fix review issues and upgrade worker to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,26 +21,14 @@ wasm-opt = false
 crate-type = ["cdylib"]
 
 [dependencies]
-worker = { version = "0.7", features = ["http", "d1"] }
+worker = { version = "0.8", features = ["http", "d1"] }
 console_error_panic_hook = { version = "0.1" }
 http = "1.4"
 serde_json = "1.0"
-cfg-if = "1.0"
-futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
-sha2 = "0.10"
-hex = "0.4"
-async-trait = "0.1"
-base64 = "0.22"
 uuid = { version = "1.23", features = ["serde", "v4", "js"] }
-
-[dependencies.web-sys]
-version = "0.3"
-features = [
-    "console",
-]
 
 [profile.release]
 lto = true

--- a/src/database.rs
+++ b/src/database.rs
@@ -26,6 +26,7 @@ pub struct DatabaseService {
 #[derive(Debug, Clone)]
 pub struct UploadChunkRecord {
     pub chunk_index: u16,
+    #[allow(dead_code)]
     pub chunk_size: u64,
     pub etag: Option<String>,
 }
@@ -198,6 +199,7 @@ impl DatabaseService {
     }
 
     /// Delete an upload and cascade chunk cleanup.
+    #[allow(dead_code)]
     pub async fn delete_upload(&self, upload_id: &str) -> AppResult<()> {
         let statement = self.db.prepare("DELETE FROM uploads WHERE upload_id = ?1");
         let statement = statement
@@ -212,6 +214,7 @@ impl DatabaseService {
     }
 
     /// List uploads for a given user, optionally filtering by status.
+    #[allow(dead_code)]
     pub async fn get_user_uploads(
         &self,
         user_id: &str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -257,7 +257,7 @@ impl AppError {
                 "KV_ERROR",
                 format!("Configuration storage error: {}", message),
             ),
-            AppError::DatabaseError { message } => (502, "DATABASE_ERROR", message.clone()),
+            AppError::DatabaseError { message } => (500, "DATABASE_ERROR", message.clone()),
             AppError::ConfigError { message } => (
                 500,
                 "CONFIG_ERROR",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -63,6 +63,7 @@ pub enum AppError {
     },
 
     /// Resource not found error.
+    #[allow(dead_code)]
     #[error("Not found: {message}")]
     NotFoundError {
         /// Not found error message
@@ -137,6 +138,7 @@ pub enum AppError {
     },
 
     /// Configuration loading or validation error.
+    #[allow(dead_code)]
     #[error("Configuration error: {message}")]
     ConfigError {
         /// Detailed configuration error message
@@ -144,6 +146,7 @@ pub enum AppError {
     },
 
     /// Authentication or authorization failure.
+    #[allow(dead_code)]
     #[error("Authentication error: {message}")]
     AuthError {
         /// Detailed authentication error message
@@ -151,6 +154,7 @@ pub enum AppError {
     },
 
     /// Rate limiting threshold exceeded.
+    #[allow(dead_code)]
     #[error("Rate limit exceeded")]
     RateLimitExceeded,
 

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -325,15 +325,13 @@ pub async fn get_upload_status(req: Request, env: &Env, config: &Config) -> AppR
     })?;
 
     let segments: Vec<&str> = url.path().split('/').collect();
-    let upload_id =
-        segments
-            .iter()
-            .rev()
-            .skip(1)
-            .next()
-            .ok_or_else(|| AppError::ValidationError {
-                message: "Upload ID missing from path".to_string(),
-            })?;
+    let upload_id = segments
+        .iter()
+        .rev()
+        .nth(1)
+        .ok_or_else(|| AppError::ValidationError {
+            message: "Upload ID missing from path".to_string(),
+        })?;
 
     let database = DatabaseService::new(env, &config.database_name)?;
     let Some(metadata) = database.get_upload(upload_id).await? else {
@@ -400,7 +398,7 @@ mod tests {
     use crate::database::UploadChunkRecord;
 
     #[test]
-    fn collect_part_descriptors_orders_parts_by_index() {
+    fn collect_part_descriptors_preserves_input_order() {
         let chunks = vec![
             UploadChunkRecord {
                 chunk_index: 1,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -56,30 +56,6 @@ use worker::*;
 pub struct CorsMiddleware;
 
 impl CorsMiddleware {
-    /// Applies CORS headers to an existing response.
-    ///
-    /// This method takes an existing response and adds the necessary CORS
-    /// headers to enable cross-origin requests. It's typically called by
-    /// handlers to ensure all responses support CORS.
-    ///
-    /// # Arguments
-    ///
-    /// * `response` - The response to which CORS headers will be added
-    ///
-    /// # Returns
-    ///
-    /// Returns the response with CORS headers applied.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// let response = Response::from_json(&data)?;
-    /// let cors_response = CorsMiddleware::apply_headers(response);
-    /// ```
-    pub fn apply_headers(response: Response) -> Response {
-        response.with_headers(cors_headers())
-    }
-
     /// Handles CORS preflight requests (OPTIONS method).
     ///
     /// Preflight requests are sent by browsers before making cross-origin
@@ -193,14 +169,20 @@ impl ValidationMiddleware {
     pub fn validate_upload_headers(req: &Request) -> AppResult<(String, u16)> {
         let upload_id = req
             .headers()
-            .get(HEADER_UPLOAD_ID)?
+            .get(HEADER_UPLOAD_ID)
+            .map_err(|err| AppError::InternalError {
+                message: format!("Failed to read {HEADER_UPLOAD_ID} header: {err}"),
+            })?
             .ok_or(AppError::MissingField {
                 field: format!("{} header", HEADER_UPLOAD_ID),
             })?;
 
         let chunk_index = req
             .headers()
-            .get(HEADER_CHUNK_INDEX)?
+            .get(HEADER_CHUNK_INDEX)
+            .map_err(|err| AppError::InternalError {
+                message: format!("Failed to read {HEADER_CHUNK_INDEX} header: {err}"),
+            })?
             .ok_or(AppError::MissingField {
                 field: format!("{} header", HEADER_CHUNK_INDEX),
             })?

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,7 +38,6 @@
 
 use crate::constants::{CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS, CORS_ALLOW_ORIGIN};
 use chrono::Utc;
-use uuid::Uuid;
 use worker::Headers;
 
 /// Generates an R2 storage key based on user context and file metadata.
@@ -188,44 +187,6 @@ fn categorize_content_type(content_type: &str) -> &'static str {
     } else {
         "other"
     }
-}
-
-/// Generates a cryptographically secure unique identifier for upload sessions.
-///
-/// This function creates a unique identifier that combines multiple entropy sources
-/// to ensure uniqueness across all upload sessions. The identifier is designed to be:
-/// - Globally unique across all workers and time periods
-/// - Sortable by creation time (timestamp prefix)
-/// - Sufficiently random to prevent guessing attacks
-/// - URL-safe and easy to handle in HTTP headers
-///
-/// # Returns
-///
-/// Returns a string identifier in the format: `{timestamp}-{uuid}-{random}`
-///
-/// # Identifier Components
-///
-/// 1. **Timestamp**: UTC milliseconds since epoch for temporal ordering
-/// 2. **UUID v4**: Cryptographically random UUID for global uniqueness
-/// 3. **Random**: Additional 64-bit random number for extra entropy
-///
-/// # Example
-///
-/// ```rust
-/// let upload_id = generate_unique_identifier();
-/// // Returns: "1641987000000-550e8400-e29b-41d4-a716-446655440000-123456789"
-/// ```
-///
-/// # Security Considerations
-///
-/// - Uses cryptographically secure random number generation
-/// - Provides sufficient entropy to prevent collision attacks
-/// - Timestamp component allows for time-based analysis and cleanup
-/// - UUID component ensures global uniqueness across distributed systems
-pub fn generate_unique_identifier() -> String {
-    let uuid_part = Uuid::new_v4().to_string();
-    let timestamp = Utc::now().timestamp_millis();
-    format!("{}-{}", timestamp, uuid_part)
 }
 
 /// Creates HTTP headers for Cross-Origin Resource Sharing (CORS) support.


### PR DESCRIPTION
## Summary
Fix code review issues (incorrect HTTP status, dead code, error misclassification) and upgrade worker SDK to 0.8 while removing 7 unused dependencies.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `worker` | 0.7 | 0.8 | Zero code changes needed; new default out-dir already matches config |
| `DatabaseError` status | 502 | 500 | D1 is internal, not an upstream gateway |
| Dead dependencies | 7 crates | removed | `sha2`, `hex`, `base64`, `cfg-if`, `futures`, `async-trait`, `web-sys` |
| Dead code | 2 functions | removed | `generate_unique_identifier`, `CorsMiddleware::apply_headers` |
| Header error handling | implicit `From` | explicit `map_err` | Prevents misclassification via string-matching |

## Details
### Upgrade worker from 0.7 to 0.8
- Breaking change in 0.8: `bucket.put().execute()` returns `Option<Object>` — not used in this project
- `worker-build` default output changed to `build/` — already matches our `wrangler.toml`

### Fix review issues
- `DatabaseError` mapped to 502 was incorrect; D1 is the service's own database, not an upstream gateway
- `validate_upload_headers` used `?` on `req.headers().get()` which propagated through `From<WorkerError>` string-matching, potentially misclassifying errors
- `rev().skip(1).next()` replaced with idiomatic `rev().nth(1)`
- Misleading test name corrected to reflect actual behavior (preserves input order, does not sort)

### Reviewer focus
- Verify `worker` 0.8 API compatibility in `src/handlers/upload.rs` and `src/database.rs`
- Confirm no transitive dependency on removed crates

## Testing
- `cargo test` — 16/16 passed
- `cargo clippy --target wasm32-unknown-unknown` — 0 errors, 3 warnings (pre-existing unused reserved variants/methods)

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable

## Risks and rollout
- Worker SDK 0.8 upgrade is backward-compatible for our API surface — verified via clippy and tests
- Removed dependencies had zero usage in source code — verified via grep

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted