### PR TITLE
refactor(core): prune dead error variants and finalize #28 cleanup

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -53,18 +53,13 @@ All API responses follow a consistent error format with appropriate HTTP status 
 | `VALIDATION_ERROR` | 400 | Request validation failed |
 | `INVALID_FIELD` | 400 | Field contains invalid value |
 | `INVALID_CHUNK_INDEX` | 400 | Chunk index out of range |
-| `AUTH_ERROR` | 401 | Authentication failure |
 | `UPLOAD_NOT_FOUND` | 404 | Upload ID not found |
-| `NOT_FOUND` | 404 | Resource not found |
 | `UPLOAD_COMPLETED` | 409 | Upload already completed |
 | `UPLOAD_CANCELLED` | 409 | Upload was cancelled |
 | `FILE_TOO_LARGE` | 413 | File exceeds maximum size limit |
-| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests |
-| `CONFIG_ERROR` | 500 | Configuration error |
+| `DATABASE_ERROR` | 500 | D1 database operation failed |
 | `INTERNAL_ERROR` | 500 | Internal server error |
-| `DATABASE_ERROR` | 502 | Database operation failed |
 | `R2_ERROR` | 502 | R2 storage operation failed |
-| `KV_ERROR` | 502 | KV storage operation failed |
 
 ## API Endpoints
 
@@ -657,7 +652,7 @@ curl -X GET "https://your-worker.workers.dev/api/upload/${UPLOAD_ID}/status"
 - Verify all chunks have been uploaded successfully
 - Check upload status before attempting completion
 
-**Database Errors (502)**
+**Database Errors (500)**
 - Verify D1 database is properly configured in wrangler.toml
 - Check database schema is applied correctly
 - Monitor D1 database metrics in Cloudflare dashboard

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,11 +190,10 @@ Files are organized in R2 storage using a hierarchical structure:
 
 ### Error Categories
 - **Client Errors (4xx)**: Invalid input, missing fields, file size limits
-- **Authentication Errors (401)**: Future authentication failures
-- **Not Found Errors (404)**: Missing uploads or invalid endpoints
-- **Conflict Errors (409)**: Upload state conflicts
-- **Server Errors (5xx)**: Internal failures, storage errors
-- **Service Errors (502)**: External service failures (R2, KV)
+- **Not Found Errors (404)**: Missing uploads
+- **Conflict Errors (409)**: Upload state conflicts (already completed / cancelled)
+- **Server Errors (500)**: D1 database failures and internal errors
+- **Upstream Errors (502)**: R2 storage failures
 
 ### Error Response Format
 ```json

--- a/src/database.rs
+++ b/src/database.rs
@@ -17,18 +17,16 @@ use worker::{d1::D1Database, wasm_bindgen::JsValue, Env};
 use crate::errors::{AppError, AppResult};
 use crate::models::{UploadMetadata, UploadStatus, UserRole};
 
-/// D1-backed persistence layer for uploads and chunk metadata.
-pub struct DatabaseService {
-    db: D1Database,
-}
-
-/// Lightweight representation of a stored chunk.
+/// Lightweight representation of a stored chunk used when finalizing uploads.
 #[derive(Debug, Clone)]
 pub struct UploadChunkRecord {
     pub chunk_index: u16,
-    #[allow(dead_code)]
-    pub chunk_size: u64,
     pub etag: Option<String>,
+}
+
+/// D1-backed persistence layer for uploads and chunk metadata.
+pub struct DatabaseService {
+    db: D1Database,
 }
 
 impl DatabaseService {
@@ -193,73 +191,15 @@ impl DatabaseService {
             .map_err(map_d1_error("record chunk"))
     }
 
-    /// Retrieve chunk metadata for an upload.
+    /// Retrieve chunk metadata for an upload, ordered by index.
     pub async fn get_upload_chunks(&self, upload_id: &str) -> AppResult<Vec<UploadChunkRecord>> {
         self.fetch_chunks(upload_id).await
-    }
-
-    /// Delete an upload and cascade chunk cleanup.
-    #[allow(dead_code)]
-    pub async fn delete_upload(&self, upload_id: &str) -> AppResult<()> {
-        let statement = self.db.prepare("DELETE FROM uploads WHERE upload_id = ?1");
-        let statement = statement
-            .bind(&[JsValue::from_str(upload_id)])
-            .map_err(map_d1_error("bind delete upload"))?;
-
-        statement
-            .run()
-            .await
-            .map(|_| ())
-            .map_err(map_d1_error("delete upload"))
-    }
-
-    /// List uploads for a given user, optionally filtering by status.
-    #[allow(dead_code)]
-    pub async fn get_user_uploads(
-        &self,
-        user_id: &str,
-        status: Option<UploadStatus>,
-    ) -> AppResult<Vec<UploadMetadata>> {
-        let (query, bindings): (&str, Vec<JsValue>) = match status {
-            Some(status) => (
-                "SELECT * FROM uploads WHERE user_id = ?1 AND status = ?2 ORDER BY created_at DESC",
-                vec![
-                    JsValue::from_str(user_id),
-                    JsValue::from_str(status.as_str()),
-                ],
-            ),
-            None => (
-                "SELECT * FROM uploads WHERE user_id = ?1 ORDER BY created_at DESC",
-                vec![JsValue::from_str(user_id)],
-            ),
-        };
-
-        let statement = self
-            .db
-            .prepare(query)
-            .bind(&bindings)
-            .map_err(map_d1_error("bind list uploads"))?;
-        let result = statement
-            .all()
-            .await
-            .map_err(map_d1_error("list uploads"))?;
-        let rows: Vec<UploadRow> = result
-            .results()
-            .map_err(map_d1_error("deserialize uploads"))?;
-
-        let mut uploads = Vec::with_capacity(rows.len());
-        for row in rows {
-            let chunks = self.fetch_chunks(&row.upload_id).await?;
-            uploads.push(row.try_into_metadata(chunks)?);
-        }
-
-        Ok(uploads)
     }
 
     /// Queries all chunks for an upload, ordered by index.
     async fn fetch_chunks(&self, upload_id: &str) -> AppResult<Vec<UploadChunkRecord>> {
         let statement = self.db.prepare(
-            "SELECT chunk_index, chunk_size, etag
+            "SELECT chunk_index, etag
              FROM upload_chunks
              WHERE upload_id = ?1
              ORDER BY chunk_index ASC",
@@ -278,7 +218,6 @@ impl DatabaseService {
             .into_iter()
             .map(|row| UploadChunkRecord {
                 chunk_index: row.chunk_index as u16,
-                chunk_size: row.chunk_size as u64,
                 etag: row.etag,
             })
             .collect())
@@ -305,7 +244,6 @@ struct UploadRow {
 #[derive(Debug, Deserialize)]
 struct ChunkRow {
     chunk_index: f64,
-    chunk_size: f64,
     etag: Option<String>,
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,8 +15,8 @@
 //! ## Error Categories
 //!
 //! - **Client Errors (4xx)**: Missing fields, invalid input, file size limits
-//! - **Server Errors (5xx)**: Storage failures, configuration issues, internal errors
-//! - **Service Errors (502)**: External service failures (R2, KV)
+//! - **Server Errors (500)**: Database failures and internal errors
+//! - **Upstream Errors (502)**: External service failures (R2)
 //!
 //! ## Example Error Response
 //!
@@ -32,7 +32,7 @@
 
 use serde_json::json;
 use thiserror::Error;
-use worker::{Error as WorkerError, Response, Result};
+use worker::{Response, Result};
 
 /// Application error enumeration covering all possible error conditions.
 ///
@@ -55,18 +55,10 @@ pub enum AppError {
         field: String,
     },
 
-    /// Request validation error (replaces MissingField and InvalidField for simplicity).
+    /// Generic request payload validation error (malformed JSON, missing body, etc.).
     #[error("Validation error: {message}")]
     ValidationError {
         /// Validation error message
-        message: String,
-    },
-
-    /// Resource not found error.
-    #[allow(dead_code)]
-    #[error("Not found: {message}")]
-    NotFoundError {
-        /// Not found error message
         message: String,
     },
 
@@ -123,40 +115,12 @@ pub enum AppError {
         message: String,
     },
 
-    /// KV storage operation failure.
-    #[error("KV storage error: {message}")]
-    KvError {
-        /// Detailed error message from KV operation
-        message: String,
-    },
-
     /// D1 Database operation failure.
     #[error("Database error: {message}")]
     DatabaseError {
         /// Detailed error message from database operation
         message: String,
     },
-
-    /// Configuration loading or validation error.
-    #[allow(dead_code)]
-    #[error("Configuration error: {message}")]
-    ConfigError {
-        /// Detailed configuration error message
-        message: String,
-    },
-
-    /// Authentication or authorization failure.
-    #[allow(dead_code)]
-    #[error("Authentication error: {message}")]
-    AuthError {
-        /// Detailed authentication error message
-        message: String,
-    },
-
-    /// Rate limiting threshold exceeded.
-    #[allow(dead_code)]
-    #[error("Rate limit exceeded")]
-    RateLimitExceeded,
 
     /// Unexpected internal server error.
     #[error("Internal server error: {message}")]
@@ -192,14 +156,12 @@ impl AppError {
     ///
     /// # Status Code Mapping
     ///
-    /// - **400**: Client errors (missing/invalid fields, invalid chunk index)
-    /// - **401**: Authentication errors
+    /// - **400**: Client errors (missing/invalid fields, invalid chunk index, validation)
     /// - **404**: Resource not found (upload not found)
     /// - **409**: Conflict errors (upload already completed/cancelled)
     /// - **413**: Payload too large (file size exceeded)
-    /// - **429**: Rate limit exceeded
-    /// - **500**: Internal server errors (config, internal)
-    /// - **502**: External service errors (R2, KV)
+    /// - **500**: Internal server errors (database, internal)
+    /// - **502**: Upstream service errors (R2)
     pub fn to_response(&self) -> Result<Response> {
         let (status, error_code, message) = self.response_parts();
 
@@ -222,7 +184,6 @@ impl AppError {
                 format!("Missing required field: {}", field),
             ),
             AppError::ValidationError { message } => (400, "VALIDATION_ERROR", message.clone()),
-            AppError::NotFoundError { message } => (404, "NOT_FOUND", message.clone()),
             AppError::InvalidField { field, reason } => (
                 400,
                 "INVALID_FIELD",
@@ -256,62 +217,12 @@ impl AppError {
             AppError::R2Error { message } => {
                 (502, "R2_ERROR", format!("Storage error: {}", message))
             }
-            AppError::KvError { message } => (
-                502,
-                "KV_ERROR",
-                format!("Configuration storage error: {}", message),
-            ),
             AppError::DatabaseError { message } => (500, "DATABASE_ERROR", message.clone()),
-            AppError::ConfigError { message } => (
-                500,
-                "CONFIG_ERROR",
-                format!("Configuration error: {}", message),
-            ),
-            AppError::AuthError { message } => (
-                401,
-                "AUTH_ERROR",
-                format!("Authentication error: {}", message),
-            ),
-            AppError::RateLimitExceeded => (
-                429,
-                "RATE_LIMIT_EXCEEDED",
-                "Rate limit exceeded. Please try again later.".to_string(),
-            ),
             AppError::InternalError { message } => (
                 500,
                 "INTERNAL_ERROR",
                 format!("Internal server error: {}", message),
             ),
-        }
-    }
-}
-
-/// Automatic conversion from Cloudflare Worker errors to application errors.
-///
-/// This implementation provides seamless error conversion from the underlying
-/// Cloudflare Workers runtime errors to our structured application errors.
-/// It analyzes the error message to determine the appropriate error category.
-///
-/// # Error Classification
-///
-/// - **"not found"**: Maps to `DatabaseError`
-/// - **"KV" or "kv"**: Maps to `KvError`
-/// - **"R2" or "bucket"**: Maps to `R2Error`
-/// - **All others**: Maps to `InternalError`
-impl From<WorkerError> for AppError {
-    fn from(err: WorkerError) -> Self {
-        let error_msg = err.to_string();
-
-        if error_msg.contains("not found") {
-            AppError::DatabaseError {
-                message: error_msg.to_string(),
-            }
-        } else if error_msg.contains("KV") || error_msg.contains("kv") {
-            AppError::KvError { message: error_msg }
-        } else if error_msg.contains("R2") || error_msg.contains("bucket") {
-            AppError::R2Error { message: error_msg }
-        } else {
-            AppError::InternalError { message: error_msg }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,8 +44,8 @@ use worker::{Response, Result};
 ///
 /// - **Validation Errors**: Missing or invalid input data
 /// - **Business Logic Errors**: Upload state violations, size limits
-/// - **Storage Errors**: Failures in R2, KV, or D1 database operations
-/// - **System Errors**: Configuration issues, rate limiting, internal failures
+/// - **Storage Errors**: R2 and D1 database operation failures
+/// - **System Errors**: Internal server failures
 #[derive(Error, Debug)]
 pub enum AppError {
     /// Required field is missing from request payload or headers.

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -373,6 +373,10 @@ struct PartDescriptor {
 }
 
 /// Extracts part number and ETag pairs from chunk records, failing if any ETag is missing.
+///
+/// Preserves input order. The caller is responsible for supplying chunks sorted by
+/// `chunk_index` ASC — `DatabaseService::fetch_chunks` enforces this via its SQL
+/// `ORDER BY`, which R2 multipart completion requires.
 fn collect_part_descriptors(chunks: &[UploadChunkRecord]) -> AppResult<Vec<PartDescriptor>> {
     let mut parts = Vec::with_capacity(chunks.len());
 
@@ -402,12 +406,10 @@ mod tests {
         let chunks = vec![
             UploadChunkRecord {
                 chunk_index: 1,
-                chunk_size: 10,
                 etag: Some("etag-two".into()),
             },
             UploadChunkRecord {
                 chunk_index: 0,
-                chunk_size: 10,
                 etag: Some("etag-one".into()),
             },
         ];
@@ -424,7 +426,6 @@ mod tests {
     fn collect_part_descriptors_fails_without_etag() {
         let chunks = vec![UploadChunkRecord {
             chunk_index: 0,
-            chunk_size: 10,
             etag: None,
         }];
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -86,34 +86,6 @@ impl CorsMiddleware {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn validate_file_size_allows_within_limit() {
-        assert!(ValidationMiddleware::validate_file_size(1_048_576, 10_485_760).is_ok());
-    }
-
-    #[test]
-    fn validate_file_size_rejects_over_limit() {
-        let err = ValidationMiddleware::validate_file_size(20, 10).unwrap_err();
-        assert!(matches!(err, AppError::FileSizeExceeded { .. }));
-    }
-
-    #[test]
-    fn validate_content_type_accepts_known_prefix() {
-        assert!(ValidationMiddleware::validate_content_type("image/png").is_ok());
-    }
-
-    #[test]
-    fn validate_content_type_rejects_unknown_type() {
-        let err =
-            ValidationMiddleware::validate_content_type("application/x-msdownload").unwrap_err();
-        assert!(matches!(err, AppError::InvalidField { .. }));
-    }
-}
-
 /// Middleware for validating request parameters and headers.
 ///
 /// This middleware provides validation functions for various aspects of
@@ -293,5 +265,33 @@ impl ValidationMiddleware {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_file_size_allows_within_limit() {
+        assert!(ValidationMiddleware::validate_file_size(1_048_576, 10_485_760).is_ok());
+    }
+
+    #[test]
+    fn validate_file_size_rejects_over_limit() {
+        let err = ValidationMiddleware::validate_file_size(20, 10).unwrap_err();
+        assert!(matches!(err, AppError::FileSizeExceeded { .. }));
+    }
+
+    #[test]
+    fn validate_content_type_accepts_known_prefix() {
+        assert!(ValidationMiddleware::validate_content_type("image/png").is_ok());
+    }
+
+    #[test]
+    fn validate_content_type_rejects_unknown_type() {
+        let err =
+            ValidationMiddleware::validate_content_type("application/x-msdownload").unwrap_err();
+        assert!(matches!(err, AppError::InvalidField { .. }));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,10 @@
 //! # Utility Functions
 //!
-//! This module provides utility functions used throughout the file storage service.
-//! It includes functions for generating unique identifiers, organizing files in storage,
-//! and handling HTTP headers for CORS support.
+//! Storage-path helpers and CORS header construction used across the service.
 //!
 //! ## Core Utilities
 //!
 //! - **R2 Key Generation**: Creates hierarchical storage paths based on user context
-//! - **Unique Identifiers**: Generates cryptographically secure upload session IDs
 //! - **CORS Headers**: Provides consistent cross-origin request support
 //!
 //! ## File Organization Strategy
@@ -18,22 +15,11 @@
 //! - Scalable storage organization
 //! - Future access control implementation
 //!
-//! ## Example Usage
+//! ## Example
 //!
 //! ```rust
-//! // Generate R2 storage key
-//! let request_body = json!({
-//!     "userRole": "creator",
-//!     "userId": "user123",
-//!     "fileName": "video.mp4",
-//!     "contentType": "video/mp4"
-//! });
-//! let key = generate_r2_key(&request_body);
+//! let key = generate_r2_key(&UserRole::Creator, "user123", "video.mp4", "video/mp4");
 //! // Result: "creator/user123/20240115/video/video.mp4"
-//!
-//! // Generate unique upload ID
-//! let upload_id = generate_unique_identifier();
-//! // Result: "1641987000000-550e8400-e29b-41d4-a716-446655440000-123456789"
 //! ```
 
 use crate::constants::{CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS, CORS_ALLOW_ORIGIN};


### PR DESCRIPTION
## Summary
Follow-up to #28: delete dead code paths surfaced by `#[allow(dead_code)]` suppressions and the `From<WorkerError> for AppError` string-matching anti-pattern, plus stale docs and a clippy lint. Net -164 lines with no behavior change.

## Related
- Follow-up to #28

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `AppError` variants | 16 | 11 | Delete 5 never-constructed variants |
| `From<WorkerError> for AppError` | string-match classifier | deleted | Latent footgun; unreachable after #28 |
| `DatabaseService` methods | 9 public | 7 public | Delete unused `delete_upload`, `get_user_uploads` |
| `UploadChunkRecord.chunk_size` | read + write | write-only path removed | DB column retained, struct field dropped |
| Stale docs | `utils.rs`, `errors.rs` | aligned with current API | Remove refs to removed `generate_unique_identifier` and retired error categories |
| `middleware.rs` tests module | mid-file | end-of-file | Fixes `clippy::items_after_test_module` |

## Details
### Prune `AppError` variants
- Deleted `NotFoundError`, `ConfigError`, `AuthError`, `RateLimitExceeded`, `KvError`. None are constructed anywhere; the previous PR suppressed warnings with `#[allow(dead_code)]` instead of removing them.
- `KvError` only ever came from the string-matching `From<WorkerError>` impl; with that gone, it is truly unreachable.
- Module doc, enum-level doc, and status-code table updated to match the reduced taxonomy.

### Delete `From<WorkerError> for AppError`
- Audited every `?` site on `worker::Result`: all remaining conversions live in `lib.rs`/`config.rs`/`router.rs`/`handlers/mod.rs` inside `worker::Result` contexts; the `From` impl was never triggered.
- Removing it forces future code to use explicit `map_err`, preventing the classification drift that motivated the partial fix in #28 (`validate_upload_headers`).

### Delete `DatabaseService::delete_upload` and `get_user_uploads`
- No callers. No routes wired. Per project conventions we do not keep speculative public APIs.
- If these are needed later they can be reintroduced with their actual wiring.

### Drop `UploadChunkRecord.chunk_size`
- Field was only populated from `SELECT` and never read. `record_chunk` still writes `chunk_size` to the `upload_chunks` table for future analytics. `ChunkRow` and the SELECT list shrink accordingly.

### Document `collect_part_descriptors` ordering precondition
- Function preserves input order by design. Added a doc note that callers must supply chunks pre-sorted by `chunk_index`, which `fetch_chunks` enforces via `ORDER BY chunk_index ASC`. No runtime sort added (trust internal code per project conventions).

### Move middleware tests to end of file
- Clippy's `items_after_test_module` was flagging `ValidationMiddleware` being declared after `#[cfg(test)] mod tests`. Pure relocation, no logic change.

### Reviewer focus
- `src/errors.rs`: confirm that no production path relied on the deleted `From<WorkerError>` conversion or any of the five removed variants.
- `src/database.rs`: verify that `chunk_size` retention in the DB is acceptable (we still write it; we just don't read it back into Rust).

## Testing
- `cargo clippy --target wasm32-unknown-unknown --all-targets` -- 0 warnings, 0 errors
- `cargo build --target wasm32-unknown-unknown` -- pass
- `CC=gcc cargo test --lib` -- 16 passed, 0 failed
- Manual steps: Not applicable

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable. No public HTTP API, error code, or DB schema change. Error enum variants were never constructed, so no behavior reachable from outside the crate changes.

## Risks and rollout
- Risk: a dependent crate importing these enum variants would fail to compile -- mitigation: this is a binary-only worker, no external consumers.
- Risk: future code adding `?` on `WorkerError` no longer auto-converts -- mitigation: intentional; the compiler now forces explicit classification.
- Note: bootstrap errors (e.g., `env.kv(...)` failure in `load_config`) bypass the structured `{"error": {...}}` JSON response format. This was already the case before this PR (the deleted `From` impl was never triggered for these paths); a separate PR can add explicit `map_err` at the bootstrap sites if structured bootstrap errors are needed.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted