### PR TITLE
fix(core): harden upload completion and align Workers config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ http = "1.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde", "wasmbind"] }
 uuid = { version = "1.23", features = ["serde", "v4", "js"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Content-Type: application/json
 ```json
 {
   "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000",
-  "chunk_size": 157286400,
+  "chunk_size": 99614720,
   "status": "initiated"
 }
 ```
@@ -197,14 +197,14 @@ The service uses KV storage for configuration with intelligent defaults:
 |---------|---------|-------------|
 | `database_name` | `UPLOAD_DB` | D1 database binding name |
 | `max_file_size` | `10737418240` | Maximum file size (10GB) |
-| `chunk_size` | `157286400` | Upload chunk size (150MB) |
+| `chunk_size` | `99614720` | Upload chunk size (95 MiB) |
 
 ### Configuration Example
 ```json
 {
   "database_name": "UPLOAD_DB",
   "max_file_size": 10737418240,
-  "chunk_size": 157286400
+  "chunk_size": 99614720
 }
 ```
 
@@ -340,13 +340,13 @@ The service provides built-in observability through:
 ## Performance
 
 ### Benchmarks
-- **Upload Throughput**: 150MB/s per chunk (edge location dependent)
+- **Upload Throughput**: ~95 MiB per chunk (edge location dependent)
 - **Concurrent Uploads**: 1000+ simultaneous uploads per worker
 - **Cold Start**: <50ms for worker initialization
 - **Chunk Processing**: <100ms per chunk including database operations
 
 ### Optimization Features
-- **Smart Chunking**: Optimal 150MB chunks for network efficiency
+- **Smart Chunking**: 95 MiB default chunks, sized to fit the Workers request body cap
 - **Parallel Processing**: Concurrent chunk uploads support
 - **Edge Caching**: Configuration cached at edge locations
 - **Connection Reuse**: Persistent connections to storage services
@@ -359,6 +359,12 @@ The service provides built-in observability through:
 - Path traversal attack prevention
 - Structured error responses (no information leakage)
 - CORS configuration for web application support
+
+> **Note**: `validate_content_type` is a coarse MIME-prefix allowlist intended to
+> catch obvious misuse, not a security boundary. The service trusts the
+> client-declared `Content-Type` and never inspects file bytes; deploy behind an
+> authenticated gateway and add content scanning if untrusted clients can call
+> the API directly.
 
 ### Future Enhancements
 - JWT-based authentication

--- a/docs/API.md
+++ b/docs/API.md
@@ -122,7 +122,7 @@ Content-Type: application/json
 ```json
 {
   "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000",
-  "chunk_size": 157286400,
+  "chunk_size": 99614720,
   "status": "initiated"
 }
 ```
@@ -565,7 +565,7 @@ Store configuration in KV under the key `config`:
 {
   "database_name": "UPLOAD_DB",
   "max_file_size": 10737418240,
-  "chunk_size": 157286400
+  "chunk_size": 99614720
 }
 ```
 
@@ -575,7 +575,7 @@ Store configuration in KV under the key `config`:
 |-------|------|---------|-------------|
 | `database_name` | string | "UPLOAD_DB" | D1 database binding name |
 | `max_file_size` | number | 10737418240 | Maximum file size in bytes (10GB) |
-| `chunk_size` | number | 157286400 | Recommended chunk size in bytes (150MB) |
+| `chunk_size` | number | 99614720 | Recommended chunk size in bytes (95 MiB) |
 
 ### Environment Setup
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -176,7 +176,7 @@ Files are organized in R2 storage using a hierarchical structure:
 - **Auto-scaling**: Zero cold starts with V8 isolation
 
 ### Upload Performance
-- **Chunked Uploads**: 150MB default chunk size
+- **Chunked Uploads**: 95 MiB default chunk size (under the Workers request body cap)
 - **Parallel Processing**: Support for concurrent chunk uploads
 - **Resumable Uploads**: State persistence enables resume capability
 - **Large File Support**: Up to 10GB file uploads
@@ -237,7 +237,7 @@ Files are organized in R2 storage using a hierarchical structure:
 
 ### Limits and Constraints
 - **File Size**: 10GB maximum (configurable)
-- **Chunk Size**: 150MB default (configurable)
+- **Chunk Size**: 95 MiB default (configurable)
 - **Concurrent Uploads**: Limited by client implementation
 - **D1 Limits**: Per Cloudflare's D1 database constraints
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -329,11 +329,11 @@ Set initial configuration in KV storage:
 
 ```bash
 # Development
-echo '{"database_name":"UPLOAD_DB","max_file_size":10737418240,"chunk_size":157286400}' | \
+echo '{"database_name":"UPLOAD_DB","max_file_size":10737418240,"chunk_size":99614720}' | \
 wrangler kv:key put "config" --binding=STORAGE_CONFIG --env=preview
 
 # Production
-echo '{"database_name":"UPLOAD_DB","max_file_size":10737418240,"chunk_size":157286400}' | \
+echo '{"database_name":"UPLOAD_DB","max_file_size":10737418240,"chunk_size":99614720}' | \
 wrangler kv:key put "config" --binding=STORAGE_CONFIG
 ```
 
@@ -341,7 +341,7 @@ wrangler kv:key put "config" --binding=STORAGE_CONFIG
 
 ```bash
 # Update max file size to 5GB
-echo '{"database_name":"UPLOAD_DB","max_file_size":5368709120,"chunk_size":157286400}' | \
+echo '{"database_name":"UPLOAD_DB","max_file_size":5368709120,"chunk_size":99614720}' | \
 wrangler kv:key put "config" --binding=STORAGE_CONFIG
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@
 //!
 //! - `database_name`: Name of the D1 database binding for upload tracking
 //! - `max_file_size`: Maximum allowed file size in bytes (default: 10GB)
-//! - `chunk_size`: Size of upload chunks in bytes (default: 150MB)
+//! - `chunk_size`: Size of upload chunks in bytes (default: 95 MiB)
 //!
 //! ## Example
 //!
@@ -53,7 +53,7 @@ impl Default for Config {
     ///
     /// Default values are optimized for:
     /// - Large file support (up to 10GB)
-    /// - Efficient chunking (150MB chunks)
+    /// - Efficient chunking (95 MiB chunks, under the Workers request body cap)
     /// - Standard D1 database binding name
     fn default() -> Self {
         Self {
@@ -94,7 +94,7 @@ impl Config {
     /// {
     ///   "database_name": "UPLOAD_DB",
     ///   "max_file_size": 10737418240,
-    ///   "chunk_size": 157286400
+    ///   "chunk_size": 99614720
     /// }
     /// ```
     ///

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -28,11 +28,17 @@ pub const UPLOAD_DB_NAME: &str = "UPLOAD_DB";
 /// Default maximum file size (10GB)
 pub const DEFAULT_MAX_FILE_SIZE: u64 = 10_737_418_240;
 
-/// Default chunk size (150MB)
-pub const DEFAULT_CHUNK_SIZE: u64 = 157_286_400;
+/// Default chunk size (95 MiB) — kept under the 100 MB Workers request body cap.
+///
+/// R2 multipart parts must be at least 5 MB except for the final part, so this
+/// default leaves ample headroom while staying within Workers' Free/Paid plan limits.
+pub const DEFAULT_CHUNK_SIZE: u64 = 95 * 1024 * 1024;
 
-/// Maximum reasonable chunk index to prevent abuse
-pub const MAX_CHUNK_INDEX: u16 = 10_000;
+/// Maximum R2/S3 multipart part number per upload (1-based).
+///
+/// Chunk indices are 0-based and map to part numbers via `part_number = chunk_index + 1`,
+/// so the highest accepted chunk index is `MAX_PART_NUMBER - 1`.
+pub const MAX_PART_NUMBER: u16 = 10_000;
 
 /// HTTP header for upload session ID
 pub const HEADER_UPLOAD_ID: &str = "X-Upload-Id";
@@ -48,3 +54,6 @@ pub const CORS_ALLOW_METHODS: &str = "GET, POST, PUT, DELETE, OPTIONS";
 
 /// CORS header for allowed headers
 pub const CORS_ALLOW_HEADERS: &str = "Content-Type, X-Upload-Id, X-Chunk-Index";
+
+/// CORS preflight cache lifetime in seconds (24 hours).
+pub const CORS_MAX_AGE: &str = "86400";

--- a/src/database.rs
+++ b/src/database.rs
@@ -21,6 +21,7 @@ use crate::models::{UploadMetadata, UploadStatus, UserRole};
 #[derive(Debug, Clone)]
 pub struct UploadChunkRecord {
     pub chunk_index: u16,
+    pub chunk_size: u64,
     pub etag: Option<String>,
 }
 
@@ -199,7 +200,7 @@ impl DatabaseService {
     /// Queries all chunks for an upload, ordered by index.
     async fn fetch_chunks(&self, upload_id: &str) -> AppResult<Vec<UploadChunkRecord>> {
         let statement = self.db.prepare(
-            "SELECT chunk_index, etag
+            "SELECT chunk_index, chunk_size, etag
              FROM upload_chunks
              WHERE upload_id = ?1
              ORDER BY chunk_index ASC",
@@ -218,6 +219,7 @@ impl DatabaseService {
             .into_iter()
             .map(|row| UploadChunkRecord {
                 chunk_index: row.chunk_index as u16,
+                chunk_size: row.chunk_size as u64,
                 etag: row.etag,
             })
             .collect())
@@ -244,6 +246,7 @@ struct UploadRow {
 #[derive(Debug, Deserialize)]
 struct ChunkRow {
     chunk_index: f64,
+    chunk_size: f64,
     etag: Option<String>,
 }
 

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use worker::{HttpMetadata, UploadedPart, *};
 
 use crate::config::Config;
-use crate::constants::{MAX_CHUNK_INDEX, STORAGE_BUCKET_NAME};
+use crate::constants::STORAGE_BUCKET_NAME;
 use crate::database::{DatabaseService, UploadChunkRecord};
 use crate::errors::{AppError, AppResult};
 use crate::middleware::ValidationMiddleware;
@@ -115,9 +115,7 @@ pub async fn initialize_upload(
 /// Upload a single chunk and persist chunk metadata.
 pub async fn upload_chunk(mut req: Request, env: &Env, config: &Config) -> AppResult<Response> {
     let (upload_id, chunk_index) = ValidationMiddleware::validate_upload_headers(&req)?;
-    if chunk_index > MAX_CHUNK_INDEX {
-        return Err(AppError::InvalidChunkIndex { index: chunk_index });
-    }
+    ValidationMiddleware::validate_chunk_index(chunk_index)?;
 
     let chunk_bytes = req.bytes().await.map_err(|err| AppError::ValidationError {
         message: format!("Failed to read chunk body: {err}"),
@@ -225,6 +223,9 @@ pub async fn complete_upload(mut req: Request, env: &Env, config: &Config) -> Ap
             message: "No uploaded chunks to finalize".to_string(),
         });
     }
+
+    verify_chunk_continuity(&chunk_records)?;
+    verify_total_size(&chunk_records, metadata.total_size)?;
 
     let uploaded_parts = build_uploaded_parts(&chunk_records)?;
 
@@ -365,6 +366,47 @@ fn build_uploaded_parts(chunks: &[UploadChunkRecord]) -> AppResult<Vec<UploadedP
     })
 }
 
+/// Ensures chunks form a contiguous sequence starting at index 0.
+///
+/// R2 multipart completion accepts non-contiguous part numbers and silently
+/// produces an object with data gaps, so callers must enforce contiguity.
+fn verify_chunk_continuity(chunks: &[UploadChunkRecord]) -> AppResult<()> {
+    for (expected, chunk) in chunks.iter().enumerate() {
+        if chunk.chunk_index as usize != expected {
+            return Err(AppError::ValidationError {
+                message: format!(
+                    "Missing chunk at index {expected}; next recorded index is {}",
+                    chunk.chunk_index
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Confirms the recorded chunk byte total matches the declared upload size.
+fn verify_total_size(chunks: &[UploadChunkRecord], declared_total: u64) -> AppResult<()> {
+    let mut actual: u64 = 0;
+    for chunk in chunks {
+        actual = actual
+            .checked_add(chunk.chunk_size)
+            .ok_or_else(|| AppError::ValidationError {
+                message: "Aggregate chunk size overflowed u64".to_string(),
+            })?;
+    }
+
+    if actual != declared_total {
+        return Err(AppError::ValidationError {
+            message: format!(
+                "Uploaded byte total {actual} does not match declared total {declared_total}"
+            ),
+        });
+    }
+
+    Ok(())
+}
+
 /// Intermediate representation of an R2 part number and its ETag.
 #[derive(Debug, PartialEq, Eq)]
 struct PartDescriptor {
@@ -406,10 +448,12 @@ mod tests {
         let chunks = vec![
             UploadChunkRecord {
                 chunk_index: 1,
+                chunk_size: 1,
                 etag: Some("etag-two".into()),
             },
             UploadChunkRecord {
                 chunk_index: 0,
+                chunk_size: 1,
                 etag: Some("etag-one".into()),
             },
         ];
@@ -426,10 +470,67 @@ mod tests {
     fn collect_part_descriptors_fails_without_etag() {
         let chunks = vec![UploadChunkRecord {
             chunk_index: 0,
+            chunk_size: 1,
             etag: None,
         }];
 
         let error = collect_part_descriptors(&chunks).unwrap_err();
         assert!(matches!(error, AppError::ValidationError { .. }));
+    }
+
+    fn chunk(index: u16, size: u64) -> UploadChunkRecord {
+        UploadChunkRecord {
+            chunk_index: index,
+            chunk_size: size,
+            etag: Some(format!("etag-{index}")),
+        }
+    }
+
+    #[test]
+    fn verify_chunk_continuity_accepts_zero_based_sequence() {
+        let chunks = vec![chunk(0, 10), chunk(1, 10), chunk(2, 5)];
+        assert!(verify_chunk_continuity(&chunks).is_ok());
+    }
+
+    #[test]
+    fn verify_chunk_continuity_rejects_missing_first_chunk() {
+        let chunks = vec![chunk(1, 10)];
+        let error = verify_chunk_continuity(&chunks).unwrap_err();
+        assert!(matches!(error, AppError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn verify_chunk_continuity_rejects_gap() {
+        let chunks = vec![chunk(0, 10), chunk(2, 10)];
+        let error = verify_chunk_continuity(&chunks).unwrap_err();
+        assert!(matches!(error, AppError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn verify_total_size_matches_declared() {
+        let chunks = vec![chunk(0, 10), chunk(1, 5)];
+        assert!(verify_total_size(&chunks, 15).is_ok());
+    }
+
+    #[test]
+    fn verify_total_size_rejects_mismatch() {
+        let chunks = vec![chunk(0, 10), chunk(1, 5)];
+        let error = verify_total_size(&chunks, 20).unwrap_err();
+        assert!(matches!(error, AppError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn verify_total_size_rejects_overflow() {
+        let chunks = vec![chunk(0, u64::MAX), chunk(1, 1)];
+        let error = verify_total_size(&chunks, 0).unwrap_err();
+        match error {
+            AppError::ValidationError { message } => {
+                assert!(
+                    message.contains("overflow"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -31,9 +31,9 @@
 //! let (upload_id, chunk_index) = ValidationMiddleware::validate_upload_headers(&req)?;
 //! ```
 
-use crate::constants::{HEADER_CHUNK_INDEX, HEADER_UPLOAD_ID};
+use crate::constants::{HEADER_CHUNK_INDEX, HEADER_UPLOAD_ID, MAX_PART_NUMBER};
 use crate::errors::{AppError, AppResult};
-use crate::utils::cors_headers;
+use crate::utils::cors_preflight_headers;
 use worker::*;
 
 /// Middleware for handling Cross-Origin Resource Sharing (CORS) requests.
@@ -82,7 +82,7 @@ impl CorsMiddleware {
     /// - Custom headers (X-Upload-Id, X-Chunk-Index)
     /// - Non-simple content types
     pub fn handle_preflight() -> Result<Response> {
-        Ok(Response::empty()?.with_headers(cors_headers()))
+        Ok(Response::empty()?.with_headers(cors_preflight_headers()))
     }
 }
 
@@ -203,6 +203,22 @@ impl ValidationMiddleware {
         Ok(())
     }
 
+    /// Validates a 0-based chunk index against the R2 multipart part-number ceiling.
+    ///
+    /// R2 caps multipart uploads at `MAX_PART_NUMBER` parts. Indexes are 0-based and
+    /// map to part numbers via `part_number = chunk_index + 1`, so the largest
+    /// accepted index is `MAX_PART_NUMBER - 1`.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidChunkIndex`: When `chunk_index >= MAX_PART_NUMBER`.
+    pub fn validate_chunk_index(chunk_index: u16) -> AppResult<()> {
+        if chunk_index >= MAX_PART_NUMBER {
+            return Err(AppError::InvalidChunkIndex { index: chunk_index });
+        }
+        Ok(())
+    }
+
     /// Validates that a content type is supported by the service.
     ///
     /// This method checks the MIME type of uploaded files against a
@@ -212,12 +228,13 @@ impl ValidationMiddleware {
     /// # Supported Content Types
     ///
     /// - `image/*` - All image formats
-    /// - `video/*` - All video formats  
+    /// - `video/*` - All video formats
     /// - `audio/*` - All audio formats
     /// - `text/*` - Text files
     /// - `application/json` - JSON documents
     /// - `application/pdf` - PDF documents
     /// - `application/zip` - ZIP archives
+    /// - `application/octet-stream` - Generic binary payloads (default fallback)
     ///
     /// # Arguments
     ///
@@ -252,6 +269,7 @@ impl ValidationMiddleware {
             "application/json",
             "application/pdf",
             "application/zip",
+            "application/octet-stream",
         ];
 
         if !ALLOWED_TYPES
@@ -284,8 +302,35 @@ mod tests {
     }
 
     #[test]
+    fn validate_chunk_index_accepts_zero() {
+        assert!(ValidationMiddleware::validate_chunk_index(0).is_ok());
+    }
+
+    #[test]
+    fn validate_chunk_index_accepts_last_legal_index() {
+        assert!(ValidationMiddleware::validate_chunk_index(MAX_PART_NUMBER - 1).is_ok());
+    }
+
+    #[test]
+    fn validate_chunk_index_rejects_first_illegal_index() {
+        let err = ValidationMiddleware::validate_chunk_index(MAX_PART_NUMBER).unwrap_err();
+        assert!(matches!(err, AppError::InvalidChunkIndex { .. }));
+    }
+
+    #[test]
+    fn validate_chunk_index_rejects_max_u16() {
+        let err = ValidationMiddleware::validate_chunk_index(u16::MAX).unwrap_err();
+        assert!(matches!(err, AppError::InvalidChunkIndex { .. }));
+    }
+
+    #[test]
     fn validate_content_type_accepts_known_prefix() {
         assert!(ValidationMiddleware::validate_content_type("image/png").is_ok());
+    }
+
+    #[test]
+    fn validate_content_type_accepts_octet_stream_default() {
+        assert!(ValidationMiddleware::validate_content_type("application/octet-stream").is_ok());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,7 @@
 //! // Result: "creator/user123/20240115/video/video.mp4"
 //! ```
 
-use crate::constants::{CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS, CORS_ALLOW_ORIGIN};
+use crate::constants::{CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS, CORS_ALLOW_ORIGIN, CORS_MAX_AGE};
 use chrono::Utc;
 use worker::Headers;
 
@@ -216,6 +216,17 @@ pub fn cors_headers() -> Headers {
     let _ = headers.set("Access-Control-Allow-Origin", CORS_ALLOW_ORIGIN);
     let _ = headers.set("Access-Control-Allow-Methods", CORS_ALLOW_METHODS);
     let _ = headers.set("Access-Control-Allow-Headers", CORS_ALLOW_HEADERS);
+    headers
+}
+
+/// Builds CORS headers tailored for preflight (OPTIONS) responses.
+///
+/// Adds `Access-Control-Max-Age` on top of the standard CORS headers so the
+/// browser can cache the preflight result. The header is meaningless on
+/// non-preflight responses and is therefore omitted from [`cors_headers`].
+pub fn cors_preflight_headers() -> Headers {
+    let headers = cors_headers();
+    let _ = headers.set("Access-Control-Max-Age", CORS_MAX_AGE);
     headers
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,9 @@
 name = "memenow-storage-cf-workers"
 main = "build/worker/shim.mjs"
-compatibility_date = "2025-08-15"
-logpush = true
+compatibility_date = "2026-03-25"
+
+[observability]
+enabled = true
 
 [placement]
 mode = "smart"
@@ -24,6 +26,3 @@ binding = "UPLOAD_DB"
 database_name = "xxxx"
 database_id = "your-prod-d1-database-id"
 preview_database_id = "your-dev-d1-database-id"
-
-[observability.logs]
-enabled = true


### PR DESCRIPTION
## Summary
Tighten correctness on the multipart upload completion path and bring the deployment configuration in line with Cloudflare Workers' request-body cap, so that incomplete uploads no longer produce silently corrupt R2 objects and the default chunk size no longer exceeds the 100 MB Workers limit.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| Chunk index ceiling | `MAX_CHUNK_INDEX = 10_000` with `>` check | `MAX_PART_NUMBER = 10_000` with `>=` check | Off-by-one let `part_number = 10_001` reach R2 |
| `complete_upload` validation | ETag presence only | + chunk continuity + declared-total byte check | Prevents silently corrupt R2 objects |
| `UploadChunkRecord` | `(chunk_index, etag)` | `(chunk_index, chunk_size, etag)` | Required for the byte-total check |
| Allowed Content-Types | excluded `application/octet-stream` | includes `application/octet-stream` | Resolves conflict with `default_content_type` |
| `DEFAULT_CHUNK_SIZE` | 150 MB (`157_286_400`) | 95 MiB (`99_614_720`) | Stays under the 100 MB Workers request body cap |
| chrono features | `["serde"]` | `["serde", "wasmbind"]` | Defensive pin; current chrono default already enables wasmbind |
| `wrangler.toml` | `compatibility_date = 2025-08-15`, `[observability.logs]`, `logpush = true`, no trailing newline | `2026-03-25`, `[observability]`, no `logpush`, trailing newline | Aligns local file with deployment template |
| CORS preflight | `Access-Control-Max-Age` on every response | `cors_preflight_headers()` adds it on OPTIONS only | Correct CORS semantics; cuts redundant headers |
| Chunk-index validation | inline `if` in `upload_chunk` | `ValidationMiddleware::validate_chunk_index` | Pure function, unit-testable |
| Tests | 22 | 31 | +9 covering boundary indexes, total-size mismatch/overflow, continuity gaps, octet-stream |
| Docs | references to 150MB / `157286400` / 'security' framing of MIME check | 95 MiB / `99614720` / explicit non-security note | README, docs/{API,ARCHITECTURE,DEPLOYMENT}.md |

## Details
### Harden `complete_upload`
- Design/Spec: R2/S3 multipart `CompleteMultipartUpload` accepts non-contiguous part lists and produces objects with missing data when parts are skipped. The server is the only component that can detect missing chunks before completion.
- Implementation notes: `verify_chunk_continuity` walks the SQL-ordered chunk list and asserts `chunk_index == enumerate index`; `verify_total_size` sums recorded `chunk_size` with `checked_add` and compares against the client-declared `total_size`. Both run before `build_uploaded_parts`.
- Reviewer focus: Confirm the SQL `ORDER BY chunk_index ASC` invariant is preserved everywhere `fetch_chunks` is called, and that `record_chunk` actually persists the byte length (it does — `chunk_bytes.len() as u64`).

### `MAX_PART_NUMBER` off-by-one
- Implementation notes: Renamed for clarity (it is now a part-number, not a chunk-index, ceiling). Comparison switched from `>` to `>=`. Logic extracted into `ValidationMiddleware::validate_chunk_index` for unit testing.
- Reviewer focus: Boundary tests in `src/middleware.rs::tests` (`0`, `MAX_PART_NUMBER - 1`, `MAX_PART_NUMBER`, `u16::MAX`).

### Default chunk size
- Implementation notes: Cloudflare Workers caps request bodies at 100 MB on Free/Bundled. The previous 150 MB default would always fail on those plans. 95 MiB leaves headroom for headers, CORS metadata, and TLS overhead.
- Reviewer focus: KV-stored configurations are not migrated; deployments with an existing `chunk_size` in KV keep their current value.

### CORS preflight scope
- Implementation notes: `cors_headers()` is reused for normal responses; `cors_preflight_headers()` adds only the `Max-Age` on top. Only `CorsMiddleware::handle_preflight` calls the preflight variant.
- Reviewer focus: `src/router.rs` short-circuits OPTIONS before the upload-routes branch, so the standard CORS path never receives `Max-Age`.

### chrono `wasmbind`
- Implementation notes: chrono 0.4.44 already enables `wasmbind` via its default feature set, so this is a defensive pin rather than a behavior change. Kept because it documents the intent and protects against future default-feature drift.

## Testing
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings` -- clean.
- `cargo test` -- 31 / 31 passed (host target; `wasm32-unknown-unknown` does not run unit tests).
- Manual end-to-end: not run (no live Cloudflare environment in this session).

## Screenshots / Notes
- Not applicable

## Breaking changes
- None at the wire-protocol level. The upload completion contract is now stricter: clients that previously got a `200 OK` from `complete_upload` with missing chunks or a mismatched declared `total_size` will now receive `400 ValidationError`. This was already producing corrupt objects, so any caller relying on the old behavior was broken.

## Risks and rollout
- Off-by-one tightening: a client that submitted `chunk_index = 10_000` will now get `400 InvalidChunkIndex` instead of a `502 R2Error` (R2 would have rejected `part_number = 10_001` regardless). -- **Mitigation:** None needed; the new error is clearer.
- New `verify_total_size` check requires clients to honor `total_size`. Buggy clients that send fewer or more bytes will see `400` on completion. -- **Mitigation:** Error message states the actual vs. declared totals so clients can self-diagnose.
- Default `chunk_size` lowered to 95 MiB. New deployments without KV config will get smaller chunks (and therefore more parts per file). -- **Mitigation:** Existing deployments with KV-stored config are unaffected.
- `wrangler.toml` no longer enables `logpush`. -- **Mitigation:** The deployment pipeline copies `wrangler.toml.template` over `wrangler.toml` before deploying, so production was never reading the local file's `logpush` setting.

## Checklist
- [x] Tests added/updated if needed
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted