### PR TITLE
docs: refresh comments, docs, and README to match current code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,4 @@ public
 
 ./serena
 AGENTS.md
+.gitnexus

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ Content-Type: application/json
 **Response:**
 ```json
 {
-  "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "chunk_size": 99614720,
-  "status": "initiated"
+  "status": "initiated",
+  "r2_key": "creator/user123/20240112/video/video.mp4"
 }
 ```
 
@@ -110,7 +111,7 @@ Uploads a single chunk of the file.
 ```http
 PUT /api/upload/chunk
 Content-Type: application/octet-stream
-X-Upload-Id: 1641987000000-550e8400-e29b-41d4-a716-446655440000
+X-Upload-Id: 550e8400-e29b-41d4-a716-446655440000
 X-Chunk-Index: 0
 
 [Binary chunk data]
@@ -119,9 +120,10 @@ X-Chunk-Index: 0
 **Response:**
 ```json
 {
-  "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "chunk_index": 0,
-  "status": "uploaded"
+  "etag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+  "status": "in_progress"
 }
 ```
 
@@ -133,16 +135,16 @@ POST /api/upload/complete
 Content-Type: application/json
 
 {
-  "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000"
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 **Response:**
 ```json
 {
-  "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000",
-  "r2_key": "creator/user123/20240112/video/video.mp4",
-  "status": "completed"
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "completed",
+  "r2_key": "creator/user123/20240112/video/video.mp4"
 }
 ```
 
@@ -156,15 +158,12 @@ GET /api/upload/{upload_id}/status
 **Response:**
 ```json
 {
-  "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000",
-  "file_name": "video.mp4",
-  "total_size": 1073741824,
-  "user_id": "user123",
-  "user_role": "creator",
-  "content_type": "video/mp4",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "in_progress",
-  "chunks_uploaded": 5,
-  "created_at": "2024-01-12T10:30:00Z",
+  "total_size": 1073741824,
+  "chunks": [0, 1, 2, 3, 4],
+  "chunk_size": 157286400,
+  "r2_key": "creator/user123/20240112/video/video.mp4",
   "updated_at": "2024-01-12T10:35:00Z"
 }
 ```
@@ -177,14 +176,14 @@ POST /api/upload/cancel
 Content-Type: application/json
 
 {
-  "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000"
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 **Response:**
 ```json
 {
-  "upload_id": "1641987000000-550e8400-e29b-41d4-a716-446655440000",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "cancelled"
 }
 ```
@@ -314,12 +313,16 @@ The service provides structured error responses with appropriate HTTP status cod
 
 ### Common Error Codes
 - `MISSING_FIELD` (400): Required field missing from request
+- `VALIDATION_ERROR` (400): Request validation failed
 - `INVALID_FIELD` (400): Invalid field value or format
-- `FILE_TOO_LARGE` (413): File exceeds size limit
+- `INVALID_CHUNK_INDEX` (400): Chunk index out of range
 - `UPLOAD_NOT_FOUND` (404): Upload session not found
 - `UPLOAD_COMPLETED` (409): Upload already completed
-- `DATABASE_ERROR` (502): Database operation failed
-- `R2_ERROR` (502): Storage operation failed
+- `UPLOAD_CANCELLED` (409): Upload was cancelled
+- `FILE_TOO_LARGE` (413): File exceeds size limit
+- `DATABASE_ERROR` (500): D1 operation failed
+- `INTERNAL_ERROR` (500): Internal server error
+- `R2_ERROR` (502): R2 storage operation failed
 
 ## Monitoring
 
@@ -339,17 +342,16 @@ The service provides built-in observability through:
 
 ## Performance
 
-### Benchmarks
-- **Upload Throughput**: ~95 MiB per chunk (edge location dependent)
-- **Concurrent Uploads**: 1000+ simultaneous uploads per worker
-- **Cold Start**: <50ms for worker initialization
-- **Chunk Processing**: <100ms per chunk including database operations
-
-### Optimization Features
-- **Smart Chunking**: 95 MiB default chunks, sized to fit the Workers request body cap
-- **Parallel Processing**: Concurrent chunk uploads support
-- **Edge Caching**: Configuration cached at edge locations
-- **Connection Reuse**: Persistent connections to storage services
+### Design Choices
+- **95 MiB default chunks**: sized to stay under the Cloudflare Workers
+  request body cap while keeping multipart overhead small
+- **Concurrent chunk uploads**: chunks may be issued in parallel by the client;
+  D1 upserts on `(upload_id, chunk_index)` keep state consistent
+- **Per-isolate config cache**: `Config` is loaded from KV at most once per
+  worker isolate via `OnceLock`, keeping the per-request hot path free of KV
+  round-trips
+- **D1 indexes**: indexes on `user_id`, `status`, `created_at`, `user_role`
+  back the typical query patterns (see `schema.sql`)
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ GET /api/upload/{upload_id}/status
   "status": "in_progress",
   "total_size": 1073741824,
   "chunks": [0, 1, 2, 3, 4],
-  "chunk_size": 157286400,
+  "chunk_size": 99614720,
   "r2_key": "creator/user123/20240112/video/video.mp4",
   "updated_at": "2024-01-12T10:35:00Z"
 }
@@ -267,7 +267,7 @@ subscriber/user789/20240112/document/report.pdf
    wrangler d1 execute memenow-uploads --file schema.sql
 
    # Create KV namespace
-   wrangler kv:namespace create "STORAGE_CONFIG"
+   wrangler kv namespace create "STORAGE_CONFIG"
    ```
 
 4. **Configure wrangler.toml**
@@ -340,7 +340,7 @@ The service provides built-in observability through:
 - R2 storage operation metrics
 - Custom error tracking
 
-## Performance
+## Performance & Design
 
 ### Design Choices
 - **95 MiB default chunks**: sized to stay under the Cloudflare Workers

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,16 +114,17 @@ Content-Type: application/json
 | `file_name` | string | Yes | Original filename |
 | `total_size` | number | Yes | Total file size in bytes |
 | `user_role` | string | Yes | User role: `creator`, `member`, or `subscriber` |
-| `content_type` | string | Yes | MIME type of the file |
 | `user_id` | string | Yes | Unique user identifier |
+| `content_type` | string | No | MIME type of the file. Defaults to `application/octet-stream`. |
 
 #### Initialize Upload Response
 
 ```json
 {
-  "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "chunk_size": 99614720,
-  "status": "initiated"
+  "status": "initiated",
+  "r2_key": "creator/user_12345/20240115/video/example.mp4"
 }
 ```
 
@@ -131,9 +132,10 @@ Content-Type: application/json
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `upload_id` | string | Unique upload session identifier |
+| `upload_id` | string | Upload session identifier (UUID v4) |
 | `chunk_size` | number | Recommended chunk size in bytes |
-| `status` | string | Current upload status |
+| `status` | string | Initial upload status (`initiated`) |
+| `r2_key` | string | R2 storage path that will hold the final object |
 
 **Status Codes:**
 - `200` - Upload initialized successfully
@@ -169,9 +171,10 @@ Binary data representing the file chunk.
 
 ```json
 {
-  "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "chunk_index": 0,
-  "status": "uploaded"
+  "etag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+  "status": "in_progress"
 }
 ```
 
@@ -181,12 +184,14 @@ Binary data representing the file chunk.
 |-------|------|-------------|
 | `upload_id` | string | Upload session identifier |
 | `chunk_index` | number | Index of the uploaded chunk |
-| `status` | string | Status of the chunk upload |
+| `etag` | string | R2 ETag returned for the uploaded part |
+| `status` | string | Overall upload status after the chunk landed (typically `in_progress`) |
 
 **Status Codes:**
 - `200` - Chunk uploaded successfully
-- `400` - Invalid headers or chunk data
+- `400` - Invalid headers, empty body, or out-of-range chunk index
 - `404` - Upload session not found
+- `409` - Upload already completed or cancelled
 
 ---
 
@@ -203,7 +208,7 @@ Content-Type: application/json
 
 ```json
 {
-  "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000"
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -217,9 +222,9 @@ Content-Type: application/json
 
 ```json
 {
-  "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000",
-  "r2_key": "creator/user_12345/20240105/video/example.mp4",
-  "status": "completed"
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "completed",
+  "r2_key": "creator/user_12345/20240105/video/example.mp4"
 }
 ```
 
@@ -250,15 +255,12 @@ GET /api/upload/{upload_id}/status
 
 ```json
 {
-  "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000",
-  "file_name": "example.mp4",
-  "total_size": 524288000,
-  "user_id": "user_12345",
-  "user_role": "creator",
-  "content_type": "video/mp4",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "in_progress",
-  "chunks_uploaded": 5,
-  "created_at": "2024-01-05T10:30:00Z",
+  "total_size": 524288000,
+  "chunks": [0, 1, 2, 3, 4],
+  "chunk_size": 157286400,
+  "r2_key": "creator/user_12345/20240105/video/example.mp4",
   "updated_at": "2024-01-05T10:35:00Z"
 }
 ```
@@ -268,14 +270,11 @@ GET /api/upload/{upload_id}/status
 | Field | Type | Description |
 |-------|------|-------------|
 | `upload_id` | string | Upload session identifier |
-| `file_name` | string | Original filename |
-| `total_size` | number | Total file size in bytes |
-| `user_id` | string | User identifier |
-| `user_role` | string | User role |
-| `content_type` | string | MIME type |
 | `status` | string | Current upload status |
-| `chunks_uploaded` | number | Number of chunks uploaded |
-| `created_at` | string | Upload creation timestamp (ISO 8601) |
+| `total_size` | number | Total file size in bytes (as declared at init) |
+| `chunks` | number[] | Indices of chunks that have been successfully uploaded |
+| `chunk_size` | number | Recommended chunk size in bytes |
+| `r2_key` | string | R2 storage path for the final object |
 | `updated_at` | string | Last update timestamp (ISO 8601) |
 
 ##### Status Values
@@ -304,7 +303,7 @@ Content-Type: application/json
 
 ```json
 {
-  "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000"
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -312,7 +311,7 @@ Content-Type: application/json
 
 ```json
 {
-  "upload_id": "1704447000000-550e8400-e29b-41d4-a716-446655440000",
+  "upload_id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "cancelled"
 }
 ```
@@ -320,6 +319,7 @@ Content-Type: application/json
 **Status Codes:**
 - `200` - Upload cancelled successfully
 - `404` - Upload session not found
+- `409` - Upload already completed or cancelled
 
 ## File Organization
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -259,7 +259,7 @@ GET /api/upload/{upload_id}/status
   "status": "in_progress",
   "total_size": 524288000,
   "chunks": [0, 1, 2, 3, 4],
-  "chunk_size": 157286400,
+  "chunk_size": 99614720,
   "r2_key": "creator/user_12345/20240105/video/example.mp4",
   "updated_at": "2024-01-05T10:35:00Z"
 }
@@ -272,7 +272,7 @@ GET /api/upload/{upload_id}/status
 | `upload_id` | string | Upload session identifier |
 | `status` | string | Current upload status |
 | `total_size` | number | Total file size in bytes (as declared at init) |
-| `chunks` | number[] | Indices of chunks that have been successfully uploaded |
+| `chunks` | number[] | Zero-based chunk indices (`u16`) that have been successfully uploaded |
 | `chunk_size` | number | Recommended chunk size in bytes |
 | `r2_key` | string | R2 storage path for the final object |
 | `updated_at` | string | Last update timestamp (ISO 8601) |
@@ -344,10 +344,12 @@ Files are organized in R2 storage using a structured path format that facilitate
 
 ### Example Paths
 
+The date segment is the upload day in UTC (`YYYYMMDD`).
+
 ```text
-creator/user123/20240115/image/profile.jpg
-member/user456/20240115/video/presentation.mp4
-subscriber/user789/20240115/document/report.pdf
+creator/user123/<YYYYMMDD>/image/profile.jpg
+member/user456/<YYYYMMDD>/video/presentation.mp4
+subscriber/user789/<YYYYMMDD>/document/report.pdf
 ```
 
 This structure enables:
@@ -592,7 +594,7 @@ Store configuration in KV under the key `config`:
 
 3. Create KV namespace:
    ```bash
-   wrangler kv:namespace create "STORAGE_CONFIG"
+   wrangler kv namespace create "STORAGE_CONFIG"
    ```
 
 ## Testing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,10 +64,11 @@ MemeNow Storage is a high-performance, edge-based file storage service built wit
 ### 4. Database Layer (`src/database.rs`)
 - **Primary Function**: Persistent upload state management via D1
 - **DatabaseService Responsibilities**:
-  - Upload CRUD operations (create, read, update, delete)
-  - Chunk progress tracking with upsert semantics
-  - Status lifecycle management
-  - User upload listing with optional status filtering
+  - Create upload metadata records (`create_upload`)
+  - Load upload metadata with associated chunk indices (`get_upload`)
+  - Track per-chunk progress with upsert semantics (`record_chunk`)
+  - Update upload status and `updated_at` timestamps (`update_upload_status`, `touch_upload`)
+  - Read chunks ordered by index for multipart completion (`get_upload_chunks`)
   - Row deserialization with timestamp and enum parsing
 
 ### 5. Models Layer (`src/models.rs`)
@@ -95,9 +96,12 @@ MemeNow Storage is a high-performance, edge-based file storage service built wit
 ### 8. Utilities (`src/utils.rs`)
 - **Primary Function**: Shared utility functions
 - **Features**:
-  - R2 key generation with hierarchical organization
-  - Cryptographically secure upload ID generation
-  - CORS header standardization
+  - R2 key generation with hierarchical organization (`generate_r2_key`)
+  - Path component and filename sanitization
+  - CORS header standardization (`cors_headers`)
+
+Upload identifiers are generated inline in the upload handler via
+[`uuid::Uuid::new_v4`].
 
 ## Data Flow
 
@@ -105,29 +109,37 @@ MemeNow Storage is a high-performance, edge-based file storage service built wit
 ```
 1. Client → POST /api/upload/init
 2. Router → CORS check → Upload handler
-3. Handler → Validate request → R2.create_multipart_upload()
-4. Handler → DatabaseService.create_upload() → Persist metadata in D1
-5. Response → Upload ID + R2 key + chunk_size
+3. Handler → ValidationMiddleware (file size, content type)
+4. Handler → R2.create_multipart_upload()
+5. Handler → DatabaseService.create_upload() → persist metadata in D1
+6. Response → { upload_id, chunk_size, status, r2_key }
 ```
 
 ### Chunk Upload Flow
 ```
-1. Client → PUT /api/upload/chunk + headers
-2. Router → Validation middleware → Upload handler
-3. Handler → DatabaseService.get_upload() → Load metadata from D1
-4. Handler → Validate state → R2.upload_part()
-5. Handler → DatabaseService.record_chunk() → Update progress in D1
-6. Response → Chunk confirmation + ETag
+1. Client → PUT /api/upload/chunk + X-Upload-Id + X-Chunk-Index
+2. Router → ValidationMiddleware.validate_upload_headers()
+3. Handler → ValidationMiddleware.validate_chunk_index()
+4. Handler → DatabaseService.get_upload() → load metadata from D1
+5. Handler → reject if status is Completed/Cancelled
+6. Handler → R2.resume_multipart_upload().upload_part()
+7. Handler → DatabaseService.record_chunk() → upsert chunk row in D1
+8. Handler → transition status Initiated → InProgress on first chunk,
+   otherwise DatabaseService.touch_upload()
+9. Response → { upload_id, chunk_index, etag, status }
 ```
 
 ### Upload Completion Flow
 ```
-1. Client → POST /api/upload/complete
-2. Router → Upload handler
-3. Handler → DatabaseService.get_upload() → Load metadata + chunks from D1
-4. Handler → R2.complete_multipart_upload()
-5. Handler → DatabaseService.update_upload_status() → Mark completed in D1
-6. Response → Completion confirmation + R2 key
+1. Client → POST /api/upload/complete { upload_id }
+2. Handler → DatabaseService.get_upload() → load metadata
+3. Handler → DatabaseService.get_upload_chunks() → fetch chunks ordered by index
+4. Handler → verify_chunk_continuity() (no gaps, starts at 0)
+5. Handler → verify_total_size() (sum of chunk_size == declared total_size)
+6. Handler → assemble UploadedPart list (chunk_index + 1, etag)
+7. Handler → R2.resume_multipart_upload().complete(parts)
+8. Handler → DatabaseService.update_upload_status(Completed)
+9. Response → { upload_id, status, r2_key }
 ```
 
 ## File Organization Strategy
@@ -154,9 +166,13 @@ Files are organized in R2 storage using a hierarchical structure:
 
 ### Upload Security
 - **File Size Limits**: Configurable maximum file size (default: 10GB)
-- **Content Type Validation**: Whitelist of allowed MIME types
-- **Unique Identifiers**: Cryptographically secure upload session IDs
-- **Chunk Validation**: ETag verification for uploaded chunks
+- **Content Type Validation**: Whitelist of allowed MIME type prefixes
+- **Path Sanitization**: User IDs, role, and filename are sanitized before
+  composing the R2 key (alphanumeric/`-`/`_` only for components; control
+  characters and path separators stripped from filenames)
+- **Chunk Index Cap**: Refuses chunk indices `>= MAX_PART_NUMBER` (10 000), the R2 multipart part-number ceiling
+- **Completion Integrity**: At completion, `verify_chunk_continuity` rejects gapped chunk sequences and `verify_total_size` rejects mismatched aggregate byte counts
+- **Unique Identifiers**: UUID v4 upload session IDs
 
 ### CORS Configuration
 - **Origin Policy**: Currently allows all origins (`*`)
@@ -172,19 +188,20 @@ Files are organized in R2 storage using a hierarchical structure:
 
 ### Edge Performance
 - **Global Distribution**: Deployed to Cloudflare's edge network
-- **Sub-50ms Latency**: Worldwide response times
-- **Auto-scaling**: Zero cold starts with V8 isolation
+- **V8 Isolates**: Per-isolate `OnceLock` cache for `Config` keeps the KV
+  round-trip out of the per-request path
 
 ### Upload Performance
 - **Chunked Uploads**: 95 MiB default chunk size (under the Workers request body cap)
-- **Parallel Processing**: Support for concurrent chunk uploads
-- **Resumable Uploads**: State persistence enables resume capability
-- **Large File Support**: Up to 10GB file uploads
+- **Parallel Processing**: Clients may upload chunks concurrently
+- **Resumable Uploads**: Per-chunk state persistence enables resume from the
+  last successfully recorded chunk
+- **Large File Support**: Up to 10GB file uploads (configurable)
 
 ### Storage Performance
-- **R2 Integration**: High-performance object storage
-- **Multipart Uploads**: Efficient handling of large files
-- **Global Availability**: R2's global distribution
+- **R2 Integration**: Multipart upload API used end-to-end
+- **D1 Indexes**: `uploads(user_id|status|created_at|user_role)` and
+  `upload_chunks(upload_id)` defined in `schema.sql`
 
 ## Error Handling Strategy
 
@@ -213,15 +230,9 @@ Files are organized in R2 storage using a hierarchical structure:
 - Returns: Service identification, status, timestamp
 
 ### Logging
-- Request/response logging via `console_log!`
-- D1 query operation logging
-- Error context preservation
-
-### Metrics (Future)
-- Upload success/failure rates
-- Chunk upload performance
-- Storage utilization
-- Error rate tracking
+- Request method + path logged on entry via `console_log!`
+- Worker observability enabled in `wrangler.toml`
+- Error responses include UTC timestamps for correlation
 
 ## Scalability Considerations
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -80,10 +80,10 @@ wrangler r2 bucket create memenow-storage-prod
 
 ```bash
 # Development namespace
-wrangler kv:namespace create "STORAGE_CONFIG" --preview
+wrangler kv namespace create "STORAGE_CONFIG" --preview
 
 # Production namespace
-wrangler kv:namespace create "STORAGE_CONFIG"
+wrangler kv namespace create "STORAGE_CONFIG"
 ```
 
 Note the namespace IDs returned by these commands.
@@ -278,11 +278,11 @@ Set initial configuration in KV storage:
 ```bash
 # Development
 echo '{"database_name":"UPLOAD_DB","max_file_size":10737418240,"chunk_size":99614720}' | \
-wrangler kv:key put "config" --binding=STORAGE_CONFIG --env=preview
+wrangler kv key put "config" --binding=STORAGE_CONFIG --env=preview
 
 # Production
 echo '{"database_name":"UPLOAD_DB","max_file_size":10737418240,"chunk_size":99614720}' | \
-wrangler kv:key put "config" --binding=STORAGE_CONFIG
+wrangler kv key put "config" --binding=STORAGE_CONFIG
 ```
 
 ### Update Configuration
@@ -290,7 +290,7 @@ wrangler kv:key put "config" --binding=STORAGE_CONFIG
 ```bash
 # Update max file size to 5GB
 echo '{"database_name":"UPLOAD_DB","max_file_size":5368709120,"chunk_size":99614720}' | \
-wrangler kv:key put "config" --binding=STORAGE_CONFIG
+wrangler kv key put "config" --binding=STORAGE_CONFIG
 ```
 
 ## Resource Naming Convention
@@ -372,7 +372,7 @@ wrangler d1 execute your-db --file=schema.sql
 ```bash
 # Check current bindings
 wrangler whoami
-wrangler kv:namespace list
+wrangler kv namespace list
 wrangler d1 list
 wrangler r2 bucket list
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -179,85 +179,33 @@ curl -X POST http://localhost:8787/api/upload/init \
 
 Set these in your GitHub repository settings (Settings → Secrets and variables → Actions):
 
-| Secret Name | Description | Example Value |
-|------------|-------------|---------------|
-| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with Workers permissions | `your-api-token` |
-| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID | `your-account-id` |
-| `PROD_KV_NAMESPACE_ID` | Production KV namespace ID | `2437be2b7fa24e70b7b8c50718ec79ac` |
-| `DEV_KV_NAMESPACE_ID` | Development KV namespace ID | `8cdac03553594d1081cd367089313116` |
-| `PROD_D1_DATABASE_ID` | Production D1 database ID | `your-prod-d1-id` |
-| `DEV_D1_DATABASE_ID` | Development D1 database ID | `your-dev-d1-id` |
-
-### Create Deployment Workflow
-
-Create `.github/workflows/deploy.yml`:
-
-```yaml
-name: Deploy to Cloudflare Workers
-
-on:
-  push:
-    branches: [main]
-  release:
-    types: [published]
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'release' && 'production' || 'preview' }}
-    
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          
-      - name: Install worker-build
-        run: cargo install worker-build
-        
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          
-      - name: Install wrangler
-        run: npm install -g wrangler
-        
-      - name: Generate wrangler.toml
-        run: |
-          envsubst < wrangler.toml.template > wrangler.toml
-        env:
-          PROD_KV_NAMESPACE_ID: ${{ secrets.PROD_KV_NAMESPACE_ID }}
-          DEV_KV_NAMESPACE_ID: ${{ secrets.DEV_KV_NAMESPACE_ID }}
-          PROD_D1_DATABASE_ID: ${{ secrets.PROD_D1_DATABASE_ID }}
-          DEV_D1_DATABASE_ID: ${{ secrets.DEV_D1_DATABASE_ID }}
-          
-      - name: Deploy to Cloudflare Workers
-        run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
-            wrangler deploy
-          else
-            wrangler deploy --env preview
-          fi
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-```
+| Secret Name | Description |
+|------------|-------------|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with Workers permissions |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |
+| `PROD_KV_NAMESPACE_ID` | Production KV namespace ID |
+| `DEV_KV_NAMESPACE_ID` | Development KV namespace ID |
+| `PROD_D1_DATABASE_NAME` | Production D1 database name |
+| `PROD_D1_DATABASE_ID` | Production D1 database ID |
+| `DEV_D1_DATABASE_ID` | Development D1 database ID |
+| `PROD_R2_BUCKET` | Production R2 bucket name |
+| `DEV_R2_BUCKET` | Development R2 bucket name |
 
 ### Deployment Workflow
 
-The GitHub Actions workflow automatically:
+The canonical workflow lives in `.github/workflows/deploy.yml`. Its behavior:
 
-1. **On push to main**: Deploys to preview environment
-2. **On release**: Deploys to production environment
-3. **Automatic setup**:
-   - Replaces template variables with secrets
-   - Builds the Rust/WASM project
-   - Deploys to Cloudflare Workers
-   - Uses existing D1 database schema
+1. **On push to `main`**: deploys to the preview environment via
+   `cloudflare/wrangler-action@v3` with `deploy --env preview`, then applies
+   `schema.sql` against the dev D1 binding (`--remote`).
+2. **On GitHub release**: deploys to production with `deploy`, then applies
+   `schema.sql` against the production D1 binding (`--remote`).
+3. **Configuration assembly**: copies `wrangler.toml.template` to
+   `wrangler.toml` and substitutes the secrets listed above via `sed`.
+
+`schema.sql` is idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF
+NOT EXISTS`, `CREATE VIEW IF NOT EXISTS`), so the schema step is safe to run
+on every deploy.
 
 ## Manual Deployment
 
@@ -347,15 +295,15 @@ wrangler kv:key put "config" --binding=STORAGE_CONFIG
 
 ## Resource Naming Convention
 
-### Development Environment
-- **KV Namespace**: `DEV_MMN_STORAGE_CONFIG`
-- **D1 Database**: `memenow-uploads-dev`
-- **R2 Bucket**: `memenow-storage-dev`
+### Recommended resource names
 
-### Production Environment
-- **KV Namespace**: `PROD_MMN_STORAGE_CONFIG`
-- **D1 Database**: `memenow-uploads-prod`
-- **R2 Bucket**: `memenow-storage-prod`
+| Environment | D1 database | R2 bucket |
+|-------------|-------------|-----------|
+| Development | `memenow-uploads-dev` | `memenow-storage-dev` |
+| Production  | `memenow-uploads-prod` | `memenow-storage-prod` |
+
+KV namespaces are referenced by ID from secrets; only the binding name
+appears in `wrangler.toml`.
 
 ### Binding Names (in code)
 - **KV Binding**: `STORAGE_CONFIG`
@@ -377,14 +325,12 @@ wrangler logpush create --compatibility-date=2025-08-15
 2. **D1 Analytics**: Track database query performance and usage
 3. **R2 Metrics**: Monitor storage operations and bandwidth usage
 
-### Custom Metrics
+### Built-in Observability
 
-The service automatically tracks:
-- Upload initialization rate
-- Chunk upload success/failure
-- Upload completion rate
-- Average upload duration
-- Error rates by type
+- Worker observability is enabled in `wrangler.toml` (`[observability.logs]`).
+- Each request is logged on entry (method + path) by the worker.
+- Error responses include a UTC timestamp and machine-readable error code
+  for correlation with logs.
 
 ## Troubleshooting
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,24 +1,19 @@
 //! # Configuration Management
 //!
-//! This module provides configuration management for the file storage service.
-//! Configuration is stored in Cloudflare KV storage and loaded at runtime with
-//! intelligent defaults for all required settings.
+//! Configuration is read from the `STORAGE_CONFIG` KV namespace under the
+//! `"config"` key when present, otherwise the service falls back to
+//! [`Config::default`].
 //!
-//! ## Configuration Sources
+//! ## Fields
 //!
-//! 1. **KV Storage**: Primary configuration source stored under the "config" key
-//! 2. **Defaults**: Fallback values when KV storage is unavailable or empty
-//!
-//! ## Configuration Options
-//!
-//! - `database_name`: Name of the D1 database binding for upload tracking
-//! - `max_file_size`: Maximum allowed file size in bytes (default: 10GB)
-//! - `chunk_size`: Size of upload chunks in bytes (default: 95 MiB)
+//! - `database_name`: D1 database binding name used by `DatabaseService`.
+//! - `max_file_size`: hard cap on `total_size` accepted at upload init (default: 10 GB).
+//! - `chunk_size`: recommended chunk size returned to clients (default: 95 MiB, kept under the Workers request body cap).
 //!
 //! ## Example
 //!
 //! ```rust
-//! let kv = env.kv("CONFIG")?;
+//! let kv = env.kv("STORAGE_CONFIG")?;
 //! let config = Config::load(&kv).await?;
 //! println!("Max file size: {} bytes", config.max_file_size);
 //! ```
@@ -67,29 +62,12 @@ impl Default for Config {
 impl Config {
     /// Loads configuration from KV storage with fallback to defaults.
     ///
-    /// This method attempts to load configuration from the "config" key in
-    /// KV storage. If no configuration is found or if there's an error
-    /// parsing the stored configuration, it falls back to default values.
+    /// Reads the `"config"` key from KV. Returns [`Config::default`] when the
+    /// key is absent. KV access errors and JSON deserialization failures are
+    /// propagated.
     ///
-    /// # Arguments
+    /// Expected KV value:
     ///
-    /// * `kv` - Reference to the KV storage instance
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result<Config>` containing either the loaded configuration
-    /// or an error if KV access fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// let kv = env.kv("CONFIG")?;
-    /// let config = Config::load(&kv).await?;
-    /// ```
-    ///
-    /// # Configuration Format
-    ///
-    /// The expected JSON format in KV storage:
     /// ```json
     /// {
     ///   "database_name": "UPLOAD_DB",
@@ -97,17 +75,6 @@ impl Config {
     ///   "chunk_size": 99614720
     /// }
     /// ```
-    ///
-    /// # Error Handling
-    ///
-    /// - If KV storage is accessible but no config exists, uses defaults
-    /// - If KV storage throws an error, the error is propagated up
-    /// - Invalid JSON in storage will cause parsing errors
-    ///
-    /// # Performance Notes
-    ///
-    /// Configuration should be loaded once per request and shared via Arc
-    /// for optimal performance in high-throughput scenarios.
     pub async fn load(kv: &KvStore) -> Result<Self> {
         match kv.get("config").json().await? {
             Some(config) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,38 +1,29 @@
 //! # MemeNow Storage - Cloudflare Workers
 //!
-//! A high-performance file storage service built with Rust and Cloudflare Workers.
-//! This service provides robust chunked upload capabilities for large files using
-//! R2 storage, D1 database for state management, and KV storage for configuration.
+//! Edge file storage service built with Rust on Cloudflare Workers. Provides
+//! chunked multipart uploads backed by R2 for object data, D1 for upload
+//! metadata, and KV for runtime configuration.
 //!
-//! ## Architecture
+//! ## Modules
 //!
-//! The service follows a modular architecture with clear separation of concerns:
-//! - **Router**: Routes incoming requests to appropriate handlers
-//! - **Middleware**: Handles CORS, validation, and error processing
-//! - **Handlers**: Process business logic for upload operations
-//! - **Database**: Manage upload state persistence with D1 SQL database
-//! - **Models**: Define data structures and types
-//! - **Utils**: Provide utility functions for file organization and ID generation
+//! - `router` — pattern-based HTTP dispatch.
+//! - `middleware` — CORS preflight, request validation.
+//! - `handlers` — upload lifecycle endpoints and health check.
+//! - `database` — D1-backed persistence for upload and chunk records.
+//! - `models` — shared types (`UploadMetadata`, `UploadStatus`, `UserRole`).
+//! - `config` — KV-loaded configuration with default fallbacks.
+//! - `errors` — structured `AppError` to HTTP response mapping.
+//! - `utils` — R2 key generation and CORS headers.
 //!
-//! ## Core Features
-//!
-//! - Chunked file uploads supporting files up to 10GB
-//! - Role-based file organization (creator/member/subscriber)
-//! - Multipart upload state management via D1 Database
-//! - Comprehensive error handling with structured responses
-//! - Configurable upload limits and chunk sizes
-//! - CORS support for web applications
-//!
-//! ## Example Usage
-//!
-//! The service exposes a REST API for file upload operations:
+//! ## Routes
 //!
 //! ```text
+//! GET  /health                      - Health check
 //! POST /api/upload/init             - Initialize a new upload
-//! PUT  /api/upload/chunk            - Upload a file chunk
-//! POST /api/upload/complete         - Complete the upload
+//! PUT  /api/upload/chunk            - Upload a chunk
+//! POST /api/upload/complete         - Finalize the multipart upload
+//! POST /api/upload/cancel           - Cancel an in-flight upload
 //! GET  /api/upload/{id}/status      - Get upload status
-//! POST /api/upload/cancel           - Cancel an upload
 //! ```
 
 use std::sync::{Arc, OnceLock};
@@ -53,50 +44,24 @@ use constants::STORAGE_CONFIG_KV_NAME;
 
 static CONFIG_CACHE: OnceLock<Arc<Config>> = OnceLock::new();
 
-/// Main entry point for the Cloudflare Worker.
+/// Worker fetch entry point.
 ///
-/// This function serves as the primary request handler that:
-/// 1. Sets up panic handling for better debugging
-/// 2. Loads configuration from KV storage with fallback to defaults
-/// 3. Delegates request routing to the router module
-///
-/// # Arguments
-///
-/// * `req` - The incoming HTTP request
-/// * `env` - Cloudflare Worker environment providing access to bindings
-/// * `_ctx` - Request context (unused in current implementation)
-///
-/// # Returns
-///
-/// Returns a `Result<Response>` containing either the HTTP response or an error.
-///
-/// # Error Handling
-///
-/// All errors are handled gracefully and converted to appropriate HTTP responses
-/// with structured error messages and proper status codes.
-///
-/// # Performance Considerations
-///
-/// - Configuration is loaded once per request and shared via Arc for efficiency
-/// - Request logging is minimal to reduce overhead
-/// - Panic hook is set only once globally
-/// - CORS headers are created per request for thread safety in WASM environment
+/// Installs the panic hook, resolves a cached `Config`, and hands the request
+/// to `router::handle_request`. Configuration is cached per worker isolate
+/// via `OnceLock`, so the KV round-trip happens at most once per isolate
+/// lifetime — not per request.
 #[event(fetch)]
 pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
-    // Set up panic hook for better error reporting in development
     console_error_panic_hook::set_once();
 
     console_log!("Request: {} {}", req.method(), req.url()?.path());
 
     let config = load_config(&env).await?;
 
-    // Route the request to appropriate handlers
     router::handle_request(req, env, config).await
 }
 
-/// Loads or retrieves cached configuration from KV storage.
-///
-/// Uses `OnceLock` to ensure config is parsed at most once per isolate lifetime.
+/// Loads configuration once per isolate and returns the cached `Arc<Config>`.
 async fn load_config(env: &Env) -> Result<Arc<Config>> {
     if let Some(config) = CONFIG_CACHE.get() {
         return Ok(config.clone());

--- a/src/models.rs
+++ b/src/models.rs
@@ -154,12 +154,9 @@ pub struct UploadMetadata {
 /// Upload lifecycle state.
 ///
 /// Transitions:
-///
-/// ```text
-/// Initiated ──first chunk──▶ InProgress ──complete──▶ Completed
-///     │                          │
-///     └──────── cancel ──────────┴──▶ Cancelled
-/// ```
+/// - `Initiated`   --first chunk-->  `InProgress`
+/// - `InProgress`  --complete-->     `Completed`
+/// - `Initiated` | `InProgress` --cancel--> `Cancelled`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum UploadStatus {

--- a/src/models.rs
+++ b/src/models.rs
@@ -102,30 +102,11 @@ impl std::str::FromStr for UserRole {
     }
 }
 
-/// Complete metadata for an upload session.
-///
-/// This structure contains all information needed to track and manage
-/// a multipart file upload. It is persisted in D1 and updated
-/// throughout the upload lifecycle.
-///
-/// # Fields
-///
-/// - `upload_id`: Unique identifier for the upload session
-/// - `file_name`: Original filename provided by the client
-/// - `total_size`: Total file size in bytes
-/// - `created_at`: UTC timestamp when upload was initiated
-/// - `updated_at`: UTC timestamp of last metadata update
-/// - `user_role`: User's role for file organization
-/// - `content_type`: MIME type of the uploaded file
-/// - `status`: Current upload status
-/// - `chunks`: List of successfully uploaded chunk indices
-/// - `r2_key`: R2 storage key for the file
-/// - `user_id`: Identifier of the uploading user
-/// - `r2_upload_id`: R2 multipart upload identifier
+/// Complete metadata for an upload session, persisted in D1 across the
+/// upload lifecycle.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct UploadMetadata {
-    /// Unique identifier for this upload session.
-    /// Generated using UUID v4 with timestamp and random components.
+    /// Unique identifier for this upload session (UUID v4).
     pub upload_id: String,
 
     /// Original filename as provided by the client.
@@ -170,21 +151,14 @@ pub struct UploadMetadata {
     pub r2_upload_id: String,
 }
 
-/// Upload status enumeration tracking the lifecycle of an upload.
+/// Upload lifecycle state.
 ///
-/// The upload status progresses through these states:
-/// 1. `Initiated` - Upload session created but no chunks uploaded
-/// 2. `InProgress` - One or more chunks have been uploaded
-/// 3. `Completed` - All chunks uploaded and multipart upload completed
-/// 4. `Cancelled` - Upload was cancelled and R2 multipart upload aborted
-///
-/// # State Transitions
+/// Transitions:
 ///
 /// ```text
-/// Initiated -> InProgress -> Completed
-///     |             |
-///     v             v
-/// Cancelled <- Cancelled
+/// Initiated ──first chunk──▶ InProgress ──complete──▶ Completed
+///     │                          │
+///     └──────── cancel ──────────┴──▶ Cancelled
 /// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,31 +1,18 @@
-//! # Request Routing and Dispatch
+//! # Request Routing
 //!
-//! This module handles HTTP request routing for the file storage service.
-//! It implements a pattern-based router that dispatches requests to appropriate
-//! handlers based on HTTP method and URL path patterns.
-//!
-//! ## Routing Strategy
-//!
-//! The router uses a simple pattern-matching approach that:
-//! - Handles CORS preflight requests automatically
-//! - Routes upload operations to D1 Database for state management
-//! - Provides health check endpoints for monitoring
-//! - Returns 404 responses for unmatched routes
+//! Pattern-based dispatcher for the file storage service. Matches HTTP method
+//! and path against a fixed route table and forwards to the appropriate
+//! handler. Handles CORS preflight early so `OPTIONS` never reaches a handler.
 //!
 //! ## Supported Routes
 //!
-//! - `GET /health` - Health check endpoint
-//! - `POST /api/upload/*` - Upload-related operations
-//! - `PUT /api/upload/*` - Upload chunk operations
-//! - `GET /api/upload/*` - Upload status queries
-//! - `OPTIONS *` - CORS preflight requests
-//!
-//! ## Architecture Benefits
-//!
-//! - **Centralized Routing**: Single point for request dispatch logic
-//! - **CORS Handling**: Automatic handling of cross-origin requests
-//! - **Database Integration**: Seamless delegation to D1 Database handlers
-//! - **Extensibility**: Easy to add new route patterns
+//! - `GET /health` — health check
+//! - `POST /api/upload/init` — initialize an upload
+//! - `PUT  /api/upload/chunk` — upload a chunk
+//! - `POST /api/upload/complete` — finalize the multipart upload
+//! - `POST /api/upload/cancel` — cancel an upload
+//! - `GET  /api/upload/{id}/status` — get upload status
+//! - `OPTIONS *` — CORS preflight
 
 use std::sync::Arc;
 use worker::*;
@@ -34,56 +21,12 @@ use crate::config::Config;
 use crate::handlers::{handle_health_check, handle_not_found, handle_upload_routes};
 use crate::middleware::CorsMiddleware;
 
-/// Handles incoming HTTP requests and routes them to appropriate handlers.
+/// Dispatches an incoming request to the appropriate handler.
 ///
-/// This function serves as the main request dispatcher for the file storage service.
-/// It implements a pattern-based routing system that matches HTTP method and path
-/// combinations to determine the appropriate handler.
-///
-/// # Request Flow
-///
-/// 1. **CORS Preflight**: Handles OPTIONS requests for cross-origin support
-/// 2. **Path Extraction**: Extracts URL path and HTTP method from request
-/// 3. **Pattern Matching**: Matches against known route patterns
-/// 4. **Handler Dispatch**: Delegates to appropriate handler function
-/// 5. **Error Handling**: Returns 404 for unmatched routes
-///
-/// # Arguments
-///
-/// * `req` - The incoming HTTP request
-/// * `env` - Cloudflare Worker environment for accessing bindings
-/// * `config` - Shared configuration loaded from KV storage
-///
-/// # Returns
-///
-/// Returns a `Result<Response>` containing either the handler response or an error.
-///
-/// # Route Patterns
-///
-/// - **Health Check**: `GET /health` → `handle_health_check`
-/// - **Upload Operations**: `/api/upload/*` → `handle_upload_routes`
-/// - **CORS Preflight**: `OPTIONS *` → `CorsMiddleware::handle_preflight`
-/// - **Unmatched**: `* *` → `handle_not_found`
-///
-/// # Example Request Flow
-///
-/// ```text
-/// POST /v1/uploads/init
-/// ↓
-/// handle_request()
-/// ↓
-/// handle_upload_routes()
-/// ↓
-/// D1 Database → DatabaseService
-/// ```
-///
-/// # Error Handling
-///
-/// - URL parsing errors are propagated up to the main handler
-/// - Unmatched routes return 404 Not Found responses
-/// - Handler-specific errors are managed by individual handlers
+/// CORS preflight is short-circuited before any path matching. Anything under
+/// `/api/upload` is delegated to [`handle_upload_routes`]; unmatched routes
+/// return 404 via [`handle_not_found`].
 pub async fn handle_request(req: Request, env: Env, config: Arc<Config>) -> Result<Response> {
-    // Handle CORS preflight requests early to avoid unnecessary processing
     if req.method() == Method::Options {
         return CorsMiddleware::handle_preflight();
     }
@@ -95,11 +38,8 @@ pub async fn handle_request(req: Request, env: Env, config: Arc<Config>) -> Resu
     console_log!("Routing request: {} {}", method, path);
 
     match (method, path) {
-        // Health check endpoint for monitoring and load balancer probes
         (Method::Get, "/health") => handle_health_check(req, env).await,
 
-        // Upload routes - all upload operations are delegated to D1 Database
-        // This ensures state consistency and proper handling of concurrent operations
         (Method::Post, path) if path.starts_with("/api/upload") => {
             handle_upload_routes(req, env, config).await
         }
@@ -110,7 +50,6 @@ pub async fn handle_request(req: Request, env: Env, config: Arc<Config>) -> Resu
             handle_upload_routes(req, env, config).await
         }
 
-        // Default 404 handler for unmatched routes
         _ => handle_not_found(req, env).await,
     }
 }


### PR DESCRIPTION
## Summary
Reconcile inline doc-comments, `README.md`, and the `docs/` tree with the actual handler shapes and runtime behavior. No behavioral changes — only comments, docs, and a small `.gitignore` addition.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `docs/API.md` | response schemas frozen at a prior API shape | aligned with `src/handlers/upload.rs` | init now lists `r2_key`; chunk lists `etag` and `status: in_progress`; status lists `chunks` array + `chunk_size` + `r2_key` + `updated_at` |
| `README.md` | DATABASE_ERROR 502, fabricated benchmarks, stale chunk response | DATABASE_ERROR 500, real design notes, real schemas | also added `INVALID_CHUNK_INDEX`, `INTERNAL_ERROR`, `UPLOAD_CANCELLED`, `VALIDATION_ERROR` to the error table |
| `docs/ARCHITECTURE.md` | mentioned `generate_upload_id`, `list_user_uploads`, "Sub-50ms latency" | references only existing symbols and behaviors | data-flow steps match the current implementation; security section calls out path sanitization and `MAX_CHUNK_INDEX` |
| `docs/DEPLOYMENT.md` | secrets list missing 3 names, outdated workflow YAML, wrong resource names | complete secrets table, description pointing to `.github/workflows/deploy.yml`, corrected naming | |
| `src/{lib,router,config,models}.rs` | long boilerplate doc-comments; wrong example `env.kv("CONFIG")`; "UUID v4 with timestamp" | trimmed; corrected to `env.kv("STORAGE_CONFIG")`; UUID v4 only; per-isolate `OnceLock` caching clarified | |
| `.gitignore` | did not ignore `.gitnexus/` | ignores `.gitnexus/` | local index directory used by GitNexus tooling |

## Details
### Reconcile docs and inline doc-comments with current code
- Design/Spec: drift accumulated over the D1 migration and the #22-#29 refactor sweep; this PR brings the published surface back in sync with `src/handlers/upload.rs`.
- Implementation notes:
  - Chunk upload response: code returns `etag` and the overall upload status (`in_progress` after the first chunk lands); docs previously claimed a per-chunk `status: "uploaded"` and omitted `etag`.
  - Status response: code returns `chunks` (array of indices), `chunk_size`, `r2_key`, `updated_at`, plus `upload_id`/`status`/`total_size`. Docs previously claimed `chunks_uploaded` count and several fields that the handler never returns.
  - `content_type` is optional in `UploadInitRequest` via `#[serde(default = "default_content_type")]`; docs now reflect that.
  - Fabricated benchmark numbers ("Sub-50ms latency", "150MB/s per chunk", "<100ms per chunk") were removed in favor of design rationale tied to the actual code.
- Reviewer focus:
  - Spot-check that the API.md / README.md response examples match what `src/handlers/upload.rs` actually returns for init, chunk, complete, status, cancel.
  - Confirm `docs/DEPLOYMENT.md` secrets table matches the `sed` substitutions in `.github/workflows/deploy.yml`.
  - Verify the simplified inline doc-comments in `src/lib.rs`, `src/router.rs`, `src/config.rs`, `src/models.rs` still convey enough context for new readers.

## Testing
- `cargo check --target wasm32-unknown-unknown` — passes.
- `cargo clippy --target wasm32-unknown-unknown` — passes, no warnings.
- `cargo test` — not run; this repo's `CLAUDE.md` notes that the local environment lacks a C linker and existing tests cannot be executed here.
- Manual steps: re-read each handler in `src/handlers/upload.rs` against the new doc snippets to confirm field-by-field alignment.

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable. No public API or wire-format changes.

## Risks and rollout
- Documentation-only PR; runtime behavior unchanged.
- Risk: readers who memorized the old (incorrect) response shape may notice fields that "look different". Reviewer focus above covers this.

## Checklist
- [x] Tests added/updated if needed — N/A (docs-only)
- [x] Docs updated if needed
- [x] Backward compatibility considered
- [x] Rollout/monitoring considerations noted